### PR TITLE
Fix CI Build (Can't confirm Publish Step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 on:
   pull_request:
   push:
-    branches: ['master']
+    branches: ['main']
   release:
     types:
       - published
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.11.12', '2.12.15', '2.13.6', '3.1.0']
+        scala: ['2.12.15', '2.13.6']
         platform: ['JVM']
     steps:
       - name: Checkout current branch
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         run: sbt ++${{ matrix.scala }}! testJVM
       - name: Compile additional subprojects
-        run: sbt ++${{ matrix.scala }}! examples/compile docs/compile benchmarks/compile
+        run: sbt ++${{ matrix.scala }}! examples/compile docs/compile
 
   ci:
     runs-on: ubuntu-20.04

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = "3.0.6"
+runner.dialect = scala213
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -56,12 +56,12 @@ lazy val core = project
 
 lazy val docs = project
   .in(file("zio-jdbc-docs"))
+  .settings(stdSettings("zio-jdbc-docs"))
   .settings(
     publish / skip                             := true,
     moduleName                                 := "zio-jdbc-docs",
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
-    crossScalaVersions --= List(ScalaDotty),
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core),
     ScalaUnidoc / unidoc / target              := (LocalRootProject / baseDirectory).value / "website" / "static" / "api",
     cleanFiles += (ScalaUnidoc / unidoc / target).value,
@@ -75,7 +75,6 @@ lazy val examples = project
   .in(file("examples"))
   .dependsOn(core)
   .settings(stdSettings("zio-jdbc-examples"))
-  .settings(dottySettings)
   .settings(
     publish / skip := true,
     libraryDependencies ++= Seq(

--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -15,13 +15,12 @@
  */
 package zio.jdbc
 
-import java.time.format.DateTimeFormatter
+import zio._
+
 import java.io._
 import java.sql.{ Array => _, _ }
-
+import java.time.format.DateTimeFormatter
 import scala.collection.immutable.ListMap
-
-import zio._
 
 /**
  * A type class that describes the ability to decode  a value of type `A` from
@@ -30,7 +29,7 @@ import zio._
 trait JdbcDecoder[+A] {
   def unsafeDecode(rs: ResultSet): A
 
-  def decode(rs: ResultSet): Either[Throwable, A] =
+  final def decode(rs: ResultSet): Either[Throwable, A] =
     try Right(unsafeDecode(rs))
     catch { case e: JdbcDecoderError => Left(e) }
 
@@ -38,7 +37,7 @@ trait JdbcDecoder[+A] {
 }
 
 object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
-  def apply[A](implicit decoder: JdbcDecoder[A]): JdbcDecoder[A] = decoder
+  def apply[A]()(implicit decoder: JdbcDecoder[A]): JdbcDecoder[A] = decoder
 
   def apply[A](f: ResultSet => A, expected: String = "value"): JdbcDecoder[A] = new JdbcDecoder[A] {
     def unsafeDecode(rs: ResultSet): A =

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -26,10 +26,9 @@ trait JdbcEncoder[-A] {
 }
 
 object JdbcEncoder {
-  def apply[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
+  def apply[A]()(implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
 
-  implicit val intEncoder: JdbcEncoder[Int] = value => sql"$value"
-
+  implicit val intEncoder: JdbcEncoder[Int]                               = value => sql"$value"
   implicit val longEncoder: JdbcEncoder[Long]                             = value => sql"$value"
   implicit val doubleEncoder: JdbcEncoder[Double]                         = value => sql"$value"
   implicit val stringEncoder: JdbcEncoder[String]                         = value => sql"$value"
@@ -46,29 +45,29 @@ object JdbcEncoder {
     value => value.fold(Sql.nullLiteral)(encoder.encode(_))
 
   implicit def tuple2Encoder[A: JdbcEncoder, B: JdbcEncoder]: JdbcEncoder[(A, B)] =
-    tuple => JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(tuple._2)
+    tuple => JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(tuple._2)
 
   implicit def tuple3Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder]: JdbcEncoder[(A, B, C)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3)
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3)
 
   implicit def tuple4Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder]
     : JdbcEncoder[(A, B, C, D)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(tuple._4)
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(tuple._4)
 
   implicit def tuple5Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder, E: JdbcEncoder]
     : JdbcEncoder[(A, B, C, D, E)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5)
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5)
 
   implicit def tuple6Encoder[
     A: JdbcEncoder,
@@ -79,11 +78,11 @@ object JdbcEncoder {
     F: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(tuple._6)
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(tuple._6)
 
   implicit def tuple7Encoder[
     A: JdbcEncoder,
@@ -95,13 +94,13 @@ object JdbcEncoder {
     G: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7)
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7)
 
   implicit def tuple8Encoder[
     A: JdbcEncoder,
@@ -114,13 +113,13 @@ object JdbcEncoder {
     H: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(tuple._8)
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(tuple._8)
 
   implicit def tuple9Encoder[
     A: JdbcEncoder,
@@ -134,15 +133,15 @@ object JdbcEncoder {
     I: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9)
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9)
 
   implicit def tuple10Encoder[
     A: JdbcEncoder,
@@ -157,15 +156,15 @@ object JdbcEncoder {
     J: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(tuple._10)
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(tuple._10)
 
   implicit def tuple11Encoder[
     A: JdbcEncoder,
@@ -181,17 +180,17 @@ object JdbcEncoder {
     K: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11)
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11)
 
   implicit def tuple12Encoder[
     A: JdbcEncoder,
@@ -208,17 +207,17 @@ object JdbcEncoder {
     L: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
       )
 
@@ -238,19 +237,19 @@ object JdbcEncoder {
     M: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13)
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13)
 
   implicit def tuple14Encoder[
     A: JdbcEncoder,
@@ -269,19 +268,19 @@ object JdbcEncoder {
     N: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
       )
 
@@ -303,21 +302,21 @@ object JdbcEncoder {
     O: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15)
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15)
 
   implicit def tuple16Encoder[
     A: JdbcEncoder,
@@ -338,21 +337,21 @@ object JdbcEncoder {
     P: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
       )
 
@@ -376,23 +375,23 @@ object JdbcEncoder {
     Q: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17)
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17)
 
   implicit def tuple18Encoder[
     A: JdbcEncoder,
@@ -415,23 +414,23 @@ object JdbcEncoder {
     R: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R]().encode(
         tuple._18
       )
 
@@ -457,25 +456,25 @@ object JdbcEncoder {
     S: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R]().encode(
         tuple._18
-      ) ++ Sql.comma ++ JdbcEncoder[S].encode(tuple._19)
+      ) ++ Sql.comma ++ JdbcEncoder[S]().encode(tuple._19)
 
   implicit def tuple20Encoder[
     A: JdbcEncoder,
@@ -500,25 +499,25 @@ object JdbcEncoder {
     T: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R]().encode(
         tuple._18
-      ) ++ Sql.comma ++ JdbcEncoder[S].encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T]().encode(
         tuple._20
       )
 
@@ -546,27 +545,27 @@ object JdbcEncoder {
     U: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R]().encode(
         tuple._18
-      ) ++ Sql.comma ++ JdbcEncoder[S].encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T]().encode(
         tuple._20
-      ) ++ Sql.comma ++ JdbcEncoder[U].encode(tuple._21)
+      ) ++ Sql.comma ++ JdbcEncoder[U]().encode(tuple._21)
 
   implicit def tuple22Encoder[
     A: JdbcEncoder,
@@ -593,27 +592,27 @@ object JdbcEncoder {
     V: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
     tuple =>
-      JdbcEncoder[A].encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B].encode(
+      JdbcEncoder[A]().encode(tuple._1) ++ Sql.comma ++ JdbcEncoder[B]().encode(
         tuple._2
-      ) ++ Sql.comma ++ JdbcEncoder[C].encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ Sql.comma ++ JdbcEncoder[D]().encode(
         tuple._4
-      ) ++ Sql.comma ++ JdbcEncoder[E].encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ Sql.comma ++ JdbcEncoder[F]().encode(
         tuple._6
-      ) ++ Sql.comma ++ JdbcEncoder[G].encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ Sql.comma ++ JdbcEncoder[H]().encode(
         tuple._8
-      ) ++ Sql.comma ++ JdbcEncoder[I].encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ Sql.comma ++ JdbcEncoder[J]().encode(
         tuple._10
-      ) ++ Sql.comma ++ JdbcEncoder[K].encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ Sql.comma ++ JdbcEncoder[L]().encode(
         tuple._12
-      ) ++ Sql.comma ++ JdbcEncoder[M].encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ Sql.comma ++ JdbcEncoder[N]().encode(
         tuple._14
-      ) ++ Sql.comma ++ JdbcEncoder[O].encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ Sql.comma ++ JdbcEncoder[P]().encode(
         tuple._16
-      ) ++ Sql.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ Sql.comma ++ JdbcEncoder[R]().encode(
         tuple._18
-      ) ++ Sql.comma ++ JdbcEncoder[S].encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ Sql.comma ++ JdbcEncoder[T]().encode(
         tuple._20
-      ) ++ Sql.comma ++ JdbcEncoder[U].encode(tuple._21) ++ Sql.comma ++ JdbcEncoder[V].encode(
+      ) ++ Sql.comma ++ JdbcEncoder[U]().encode(tuple._21) ++ Sql.comma ++ JdbcEncoder[V]().encode(
         tuple._22
       )
 

--- a/core/src/main/scala/zio/jdbc/Sql.scala
+++ b/core/src/main/scala/zio/jdbc/Sql.scala
@@ -78,17 +78,17 @@ final class Sql[+A](
   }
 
   def values[B](
-    iterable: Iterable[B]
+    iterator: Iterator[B]
   )(implicit encode: JdbcEncoder[B], ev: A <:< ZResultSet): Sql[ZResultSet] =
     Sql.values ++
       Sql.intersperse(
         Sql.comma,
-        iterable.map(b => Sql.lparen ++ encode.encode(b) ++ Sql.rparen)
+        iterator.map(b => Sql.lparen ++ encode.encode(b) ++ Sql.rparen).toIndexedSeq
       )
 
   def values[B](
     bs: B*
-  )(implicit encode: JdbcEncoder[B], ev: A <:< ZResultSet): Sql[ZResultSet] = values(bs.toIterable)
+  )(implicit encode: JdbcEncoder[B], ev: A <:< ZResultSet): Sql[ZResultSet] = values(bs.iterator)
 
   def withDecode[B](f: ZResultSet => B): Sql[B] =
     Sql(segments, f)

--- a/core/src/main/scala/zio/jdbc/ZConnectionPoolConfig.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnectionPoolConfig.scala
@@ -16,6 +16,7 @@
 package zio.jdbc
 
 import zio._
+
 import java.time.temporal.ChronoUnit
 
 /**
@@ -35,7 +36,7 @@ object ZConnectionPoolConfig {
 
   lazy val default: ZConnectionPoolConfig = ZConnectionPoolConfig(8, 32, defaultRetryPolicy, 300.seconds)
 
-  lazy val defaultRetryPolicy = Schedule.exponential(10.millis)
+  lazy val defaultRetryPolicy: Schedule.WithState[Long, Any, Any, Duration] = Schedule.exponential(10.millis)
 
   implicit val configDescriptor: ConfigDescriptor[ZConnectionPoolConfig] =
     (ConfigDescriptor.int("minConnections") zip

--- a/core/src/test/scala/zio/jdbc/SqlSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlSpec.scala
@@ -3,7 +3,7 @@ package zio.jdbc
 import zio.test._
 
 object SqlSpec extends ZIOSpecDefault {
-  def spec =
+  def spec: ZSpec[Environment with TestEnvironment, Any] =
     suite("SqlSpec") {
       test("constant") {
         assertTrue(sql"""null""".toString() == "Sql(null)")

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -1,9 +1,9 @@
 package zio.jdbc
 
 import zio._
+import zio.schema._
 import zio.test.TestAspect._
 import zio.test._
-import zio.schema._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {
   final case class Person(name: String, age: Int)
@@ -20,7 +20,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         _.age
       )
   }
-  val sherlockHolmes = User("Sherlock Holmes", 42)
+  val sherlockHolmes: User = User("Sherlock Holmes", 42)
 
   val createUsers: ZIO[ZConnectionPool with Any, Throwable, Unit] =
     transaction {
@@ -33,7 +33,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
       """)
     }
 
-  val insertSherlock =
+  val insertSherlock: ZIO[ZConnectionPool with Any, Throwable, Long] =
     transaction {
       insert {
         sql"insert into users values (default, ${sherlockHolmes.name}, ${sherlockHolmes.age})"
@@ -43,10 +43,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
   final case class User(name: String, age: Int)
   object User {
     implicit val jdbcDecoder: JdbcDecoder[User] =
-      JdbcDecoder[(String, Int)].map[User](t => User(t._1, t._2))
+      JdbcDecoder[(String, Int)]().map[User](t => User(t._1, t._2))
   }
 
-  def spec =
+  def spec: ZSpec[TestEnvironment, Any] =
     suite("ZConnectionPoolSpec") {
       suite("pool") {
         test("creation") {


### PR DESCRIPTION
https://github.com/zio/zio-jdbc/issues/8

![image](https://user-images.githubusercontent.com/1041016/153728811-f4d078be-d32c-46ee-aef3-8e99c027f7e2.png)

A number of issues preventing CI from building

- 2.11/3.1 can't be supported because of a direct dependency on `zio-schema` which to my understanding supports neither version of scala
- `benchmarks/compile` sub project does not exist
-  2.12 compilation phase exceptions/issues
   - the apply overloads which summons the encoding/decoding implicit seems to be unhappy in 2.12 without an `()` preceding the implicit argument group
   - in 2.13 calling the apply method which now has an empty paren, without those empty parens is now deprecated 2.13 and in 3 will be/is an error
 - changing `Iterable` to `Iterator` in 2.12 for the `values()` call in `Sql.scala` changing this got compilation going
 - also changed branch from `master` to `main` as there is only a `main` branch in zio-jdbc