### PR TITLE
Metric for number of open connections

### DIFF
--- a/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
@@ -164,11 +164,7 @@ object ZConnectionPool {
                   )
         pool   <-
           ZPool
-            .make(
-              managed.map(ZConnection(_)),
-              Range(config.minConnections, config.maxConnections),
-              config.timeToLive
-            )
+            .make(managed.map(ZConnection(_)), Range(config.minConnections, config.maxConnections), config.timeToLive)
       } yield ZConnectionPool {
         ZLayer.scoped {
           for {

--- a/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
@@ -26,6 +26,8 @@ import java.sql.Connection
  */
 final case class ZConnectionPool(transaction: ZLayer[Any, Throwable, ZConnection])
 object ZConnectionPool {
+  private[jdbc] val connectionsCounter = zio.metrics.Metric.counterInt("open_connections")
+
   def h2test: ZLayer[Any, Throwable, ZConnectionPool] =
     ZLayer.scoped {
       for {
@@ -152,8 +154,6 @@ object ZConnectionPool {
         zenv   <- make(acquire).build
       } yield zenv.get[ZConnectionPool]
     }
-
-  private[jdbc] val connectionsCounter = zio.metrics.Metric.counterInt("open_connections")
 
   def make(acquire: Task[Connection]): ZLayer[ZConnectionPoolConfig, Throwable, ZConnectionPool] =
     ZLayer.scoped {

--- a/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnectionPool.scala
@@ -26,7 +26,7 @@ import java.sql.Connection
  */
 final case class ZConnectionPool(transaction: ZLayer[Any, Throwable, ZConnection])
 object ZConnectionPool {
-  private[jdbc] val connectionsCounter = zio.metrics.Metric.counterInt("open_connections")
+  private[jdbc] val connectionsCounter = zio.metrics.Metric.counterInt("zio_jdbc_open_connections")
 
   def h2test: ZLayer[Any, Throwable, ZConnectionPool] =
     ZLayer.scoped {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -56,7 +56,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             state <- transaction {
-                       ZConnectionPool.connectionsGauge.value <* selectOne(sql"SELECT 1".as[Int])
+                       selectOne(sql"SELECT 1".as[Int]) *> ZConnectionPool.connectionsGauge.value
                      }
           } yield assertTrue(state.value > 0.0)
         }

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -56,10 +56,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
           } yield assertCompletes
         } + test("increment on connection acquisition") {
           for {
-            initalState <- ZConnectionPool.connectionsCounter.value
+            initalState <- ZConnectionPool.connectionsGauge.value
             _           <- transaction(execute(sql""))
-            state       <- ZConnectionPool.connectionsCounter.value
-          } yield assert(state.count - initalState.count)(isGreaterThan(0.0))
+            state       <- ZConnectionPool.connectionsGauge.value
+          } yield assert(state.value - initalState.value)(isGreaterThan(0.0))
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -1,10 +1,8 @@
 package zio.jdbc
 
-import zio.Console.printLine
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
-import zio.test.Assertion.isGreaterThanEqualTo
 import zio.test._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -57,8 +57,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             initalState <- ZConnectionPool.connectionsGauge.value
-            _           <- transaction(execute(sql""))
-            state       <- ZConnectionPool.connectionsGauge.value
+            state       <- transaction(execute(sql"").zip(ZConnectionPool.connectionsGauge.value))
           } yield assert(state.value - initalState.value)(isGreaterThan(0.0))
         }
       } +

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -3,6 +3,7 @@ package zio.jdbc
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
+import zio.test.Assertion.isGreaterThan
 import zio.test._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {
@@ -51,12 +52,14 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
       suite("pool") {
         test("creation") {
           for {
-            a <- ZIO.scoped(ZConnectionPool.h2test.build)
+            _ <- ZIO.scoped(ZConnectionPool.h2test.build)
           } yield assertCompletes
         } + test("increment on connection acquisition") {
           for {
-            _ <- zio.metrics.Metric.
-          } yield ???
+            initalState <- ZConnectionPool.connectionsCounter.value
+            _           <- createUsers
+            state       <- ZConnectionPool.connectionsCounter.value
+          } yield assert(state.count - initalState.count)(isGreaterThan(0.0))
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -51,8 +51,12 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
       suite("pool") {
         test("creation") {
           for {
-            _ <- ZIO.scoped(ZConnectionPool.h2test.build)
+            a <- ZIO.scoped(ZConnectionPool.h2test.build)
           } yield assertCompletes
+        } + test("increment on connection acquisition") {
+          for {
+            _ <- zio.metrics.Metric.
+          } yield ???
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -3,7 +3,7 @@ package zio.jdbc
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
-import zio.test.Assertion.equalTo
+import zio.test.Assertion.isGreaterThan
 import zio.test._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {
@@ -59,7 +59,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
             initalState <- ZConnectionPool.connectionsCounter.value
             _           <- transaction(execute(sql""))
             state       <- ZConnectionPool.connectionsCounter.value
-          } yield assert(state.count - initalState.count)(equalTo(8.0))
+          } yield assert(state.count - initalState.count)(isGreaterThan(0.0))
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -3,7 +3,7 @@ package zio.jdbc
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
-import zio.test.Assertion.isGreaterThan
+import zio.test.Assertion.isGreaterThanEqualTo
 import zio.test._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {
@@ -58,7 +58,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
           for {
             initalState <- ZConnectionPool.connectionsGauge.value
             state       <- createUsers.zip(ZConnectionPool.connectionsGauge.value)
-          } yield assert(state.value - initalState.value)(isGreaterThan(0.0))
+          } yield assert(state.value - initalState.value)(isGreaterThanEqualTo(0.0))
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -57,7 +57,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             initalState <- ZConnectionPool.connectionsGauge.value
-            state       <- transaction(execute(sql"").zip(ZConnectionPool.connectionsGauge.value))
+            state       <- createUsers.zip(ZConnectionPool.connectionsGauge.value)
           } yield assert(state.value - initalState.value)(isGreaterThan(0.0))
         }
       } +

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -3,7 +3,7 @@ package zio.jdbc
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
-import zio.test.Assertion.isGreaterThan
+import zio.test.Assertion.equalTo
 import zio.test._
 
 object ZConnectionPoolSpec extends ZIOSpecDefault {
@@ -57,9 +57,9 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             initalState <- ZConnectionPool.connectionsCounter.value
-            _           <- createUsers
+            _           <- transaction(execute(sql""))
             state       <- ZConnectionPool.connectionsCounter.value
-          } yield assert(state.count - initalState.count)(isGreaterThan(0.0))
+          } yield assert(state.count - initalState.count)(equalTo(8.0))
         }
       } +
         suite("sql") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -1,5 +1,6 @@
 package zio.jdbc
 
+import zio.Console.printLine
 import zio._
 import zio.schema._
 import zio.test.TestAspect._
@@ -57,7 +58,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             state <- transaction {
-                       selectOne(sql"SELECT 1".as[Int]) *> ZConnectionPool.connectionsGauge.value
+                       ZConnectionPool.connectionsGauge.value <* selectOne(sql"SELECT 1".as[Int])
                      }
           } yield assertTrue(state.value > 0.0)
         }

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -41,6 +41,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
       }
     }
 
+  val select1: ZIO[ZConnectionPool with Any, Throwable, Option[Int]] = transaction {
+    selectOne(sql"SELECT 1".as[Int])
+  }
+
   final case class User(name: String, age: Int)
   object User {
     implicit val jdbcDecoder: JdbcDecoder[User] =
@@ -57,7 +61,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
         } + test("increment on connection acquisition") {
           for {
             initalState <- ZConnectionPool.connectionsGauge.value
-            state       <- createUsers.zip(ZConnectionPool.connectionsGauge.value)
+            state       <- select1.zipRight(ZConnectionPool.connectionsGauge.value)
           } yield assert(state.value - initalState.value)(isGreaterThanEqualTo(0.0))
         }
       } +


### PR DESCRIPTION
Adding an `open_connections` metric to track the number of connections currently open in the pool. 

Is this name for the metric okay or should it be camel case and/or named something different?

I think this closes #6 but if I missed something let me know.