### PR TITLE
Invalidate connection within `ZConnectionPool`

### DIFF
--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -99,11 +99,12 @@ final class ZConnection(private[jdbc] val connection: Connection) extends AnyVal
    * @return true if the connection is alive (valid), false otherwise
    */
   def isValid(): Task[Boolean] =
-    for {
-      closed    <- ZIO.attempt(this.connection.isClosed)
-      statement <- ZIO.attempt(this.connection.prepareStatement("SELECT 1"))
-      isAlive   <- ZIO.succeed(!closed && statement != null)
-    } yield isAlive
+    ZIO.attempt(this.connection.isClosed).flatMap { b =>
+      if (b)
+        ZIO.succeed(false)
+      else
+        ZIO.attempt(this.connection.prepareStatement("SELECT 1") != null)
+    }
 
   /**
    * Returns whether the connection is still alive or not, providing a timeout,


### PR DESCRIPTION
Addresses #36. This implicates the constructor of `ZConnectionPool` - namely that the constructor is now private so that we have a handle to the underlying `ZPool` (so that we can call its `invalidate` method). I'm all ears if this encapsulation isn't necessary. Also, a sort of semi-related issue is that this PR also short circuits logic within `ZConnection.isValid` as the previous version would always fail if a connection was already closed (muddying up the intended semantics of this method).

One thing I wasn't sure of is how to properly test `invalidate`. Currently, I just get a connection, invalidate it, and check that it is closed but I am not doing any checks on the `ZPool` itself.

Any and all feedback is welcome!