### PR TITLE
Automatically invalidate invalid connections when returned back to pool

### DIFF
--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -99,11 +99,12 @@ final class ZConnection(private[jdbc] val connection: Connection) extends AnyVal
    * @return true if the connection is alive (valid), false otherwise
    */
   def isValid(): Task[Boolean] =
-    for {
-      closed    <- ZIO.attempt(this.connection.isClosed)
-      statement <- ZIO.attempt(this.connection.prepareStatement("SELECT 1"))
-      isAlive   <- ZIO.succeed(!closed && statement != null)
-    } yield isAlive
+    ZIO.attempt(this.connection.isClosed).flatMap { b =>
+      if (b)
+        ZIO.succeed(false)
+      else
+        ZIO.attempt(this.connection.prepareStatement("SELECT 1") != null)
+    }
 
   /**
    * Returns whether the connection is still alive or not, providing a timeout,

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -53,8 +53,18 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
           for {
             _ <- ZIO.scoped(ZConnectionPool.h2test.build)
           } yield assertCompletes
-        }
-      } +
+        } +
+          // TODO can we check that the connection is invalidated within underlying ZPool?
+          test("invalidate a connection") {
+            for {
+              zcp     <- ZIO.service[ZConnectionPool]
+              env     <- ZIO.scoped(zcp.transaction.build)
+              con      = env.get[ZConnection]
+              _       <- zcp.invalidate(con)
+              isValid <- con.isValid()
+            } yield assertTrue(!isValid)
+          }
+      }.provideCustomLayer(ZConnectionPool.h2test.orDie) +
         suite("sql") {
           test("create table") {
             for {


### PR DESCRIPTION
This addresses #36 and #37. Submitting as a unit for initial feedback since these two are closely related if that's OK.  

This PR makes `ZConnectionPool` a trait with a `transaction` val and an `invalidate` method to decouple from any particular implementation (looking forward to a possible implementation backed by a `HikariCP` as mentioned in #24). The `transaction` block has been lifted into the concrete `ZPool` implementation (and out of the `make` constructor and the finalizer now checks if a connection is valid, if it isn't we invalidate it from the underlying pool also closing it if necessary. I couldn't really come up with a good test for this just yet - any suggestions are very welcome.

In general, I am still pretty new to OSS contributing so any and all feedback is welcome :). 