### PR TITLE
Return generated primary keys when executing insert statements

### DIFF
--- a/core/src/main/scala/zio/jdbc/UpdateResult.scala
+++ b/core/src/main/scala/zio/jdbc/UpdateResult.scala
@@ -1,0 +1,3 @@
+package zio.jdbc
+
+final case class UpdateResult(rowsUpdated: Long, updatedKeys: ZResultSet)

--- a/core/src/main/scala/zio/jdbc/UpdateResult.scala
+++ b/core/src/main/scala/zio/jdbc/UpdateResult.scala
@@ -1,3 +1,5 @@
 package zio.jdbc
 
-final case class UpdateResult(rowsUpdated: Long, updatedKeys: ZResultSet)
+import zio.Chunk
+
+final case class UpdateResult(rowsUpdated: Long, updatedKeys: Chunk[Long])

--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -17,7 +17,7 @@ package zio.jdbc
 
 import zio._
 
-import java.sql.{ Blob, Connection, PreparedStatement }
+import java.sql.{ Blob, Connection, PreparedStatement, Statement }
 
 /**
  * A `ZConnection` is a straightforward wrapper around `java.sql.Connection`. In order
@@ -49,7 +49,7 @@ final class ZConnection(private[jdbc] val connection: Connection) extends AnyVal
         i += 1
       }
 
-      val statement = connection.prepareStatement(stringBuilder.toString)
+      val statement = connection.prepareStatement(stringBuilder.toString, Statement.RETURN_GENERATED_KEYS)
 
       i = 0
       var paramIndex = 1

--- a/core/src/main/scala/zio/jdbc/package.scala
+++ b/core/src/main/scala/zio/jdbc/package.scala
@@ -52,7 +52,10 @@ package object jdbc {
     } yield ()
 
   /**
-   * Performs a SQL update query, returning a count of rows updated.
+   * Performs an SQL insert query, returning a count of rows inserted and a
+   * [[zio.Chunk]] of auto-generated keys. By default, auto-generated keys are
+   * parsed and returned as `Chunk[Long]`. If keys are non-numeric, a
+   * `Chunk.empty` is returned.
    */
   def insert(sql: SqlFragment): ZIO[ZConnection, Throwable, UpdateResult] =
     for {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -51,7 +51,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
       """)
     }
 
-  val insertSherlock: ZIO[ZConnectionPool with Any, Throwable, Long] =
+  val insertSherlock: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
     transaction {
       insert {
         sql"insert into users values (default, ${sherlockHolmes.name}, ${sherlockHolmes.age})"
@@ -133,9 +133,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
             } +
               test("insert") {
                 for {
-                  _   <- createUsers
-                  num <- insertSherlock
-                } yield assertTrue(num == 1L)
+                  _      <- createUsers
+                  result <- insertSherlock
+                  hasKey <- result.updatedKeys.access(_.next())
+                } yield assertTrue(result.rowsUpdated == 1L) && assertTrue(hasKey)
               } +
               test("select one") {
                 for {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -135,8 +135,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                 for {
                   _      <- createUsers
                   result <- insertSherlock
-                  hasKey <- result.updatedKeys.access(_.next())
-                } yield assertTrue(result.rowsUpdated == 1L) && assertTrue(hasKey)
+                } yield assertTrue(result.rowsUpdated == 1L) && assertTrue(result.updatedKeys.nonEmpty)
               } +
               test("select one") {
                 for {

--- a/examples/src/main/scala/zio/jdbc/examples/App.scala
+++ b/examples/src/main/scala/zio/jdbc/examples/App.scala
@@ -14,7 +14,7 @@ object App extends ZIOAppDefault {
     execute(Basic.ex0)
   }
 
-  val insertRow: ZIO[ZConnectionPool, Throwable, Long] = transaction {
+  val insertRow: ZIO[ZConnectionPool, Throwable, UpdateResult] = transaction {
     insert(sql"insert into users (name, age)".values(sampleUser1, sampleUser2))
   }
 


### PR DESCRIPTION
Addresses #76 

This adds `Statement.RETURN_GENERATED_KEYS` in `ZConnection.executeSqlWith`, hence *prepared statements for all SQL operations* will have this parameter. According to the [docs](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Connection.html#prepareStatement(java.lang.String,int)) this shouldn't be an issue; if we have reservations, we can extract the SQL template string creation and statement parameter insertion from `executeSqlWith` into their own functions, and have a separate `executeInsertSqlWith` just for the insert operation.