### PR TITLE
Improve dbcEncoder.fromSchema: Support Transform, Lazy and simple Enum schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.15', '2.13.6']
+        scala: ['2.12.17', '2.13.10']
         platform: ['JVM']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.17', '2.13.10']
+        scala: ['2.12.17', '2.13.10', '3.2.1']
         platform: ['JVM']
     steps:
       - name: Checkout current branch

--- a/build.sbt
+++ b/build.sbt
@@ -40,14 +40,15 @@ lazy val core = project
   .settings(stdSettings("zio-jdbc"))
   .settings(
     libraryDependencies ++= Seq(
-      "dev.zio"       %% "zio"          % ZioVersion,
-      "dev.zio"       %% "zio-streams"  % ZioVersion,
-      "dev.zio"       %% "zio-config"   % ZioConfigVersion,
-      "dev.zio"       %% "zio-logging"  % ZioLoggingVersion,
-      "dev.zio"       %% "zio-schema"   % ZioSchemaVersion,
-      "dev.zio"       %% "zio-test"     % ZioVersion % Test,
-      "dev.zio"       %% "zio-test-sbt" % ZioVersion % Test,
-      "com.h2database" % "h2"           % H2Version  % Test
+      "dev.zio"       %% "zio"                   % ZioVersion,
+      "dev.zio"       %% "zio-streams"           % ZioVersion,
+      "dev.zio"       %% "zio-config"            % ZioConfigVersion,
+      "dev.zio"       %% "zio-logging"           % ZioLoggingVersion,
+      "dev.zio"       %% "zio-schema"            % ZioSchemaVersion,
+      "dev.zio"       %% "zio-schema-derivation" % ZioSchemaVersion % Test,
+      "dev.zio"       %% "zio-test"              % ZioVersion       % Test,
+      "dev.zio"       %% "zio-test-sbt"          % ZioVersion       % Test,
+      "com.h2database" % "h2"                    % H2Version        % Test
     ),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
     Test / fork    := true,

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val ZioVersion        = "2.0.4"
 val H2Version         = "2.1.214"
 val ZioConfigVersion  = "3.0.2"
 val ZioLoggingVersion = "2.1.5"
-val ZioSchemaVersion  = "0.2.1"
+val ZioSchemaVersion  = "0.3.1"
 
 name := "zio-jdbc"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import BuildHelper._
 
-val ZioVersion        = "2.0.2"
-val H2Version         = "2.1.210"
+val ZioVersion        = "2.0.4"
+val H2Version         = "2.1.214"
 val ZioConfigVersion  = "3.0.2"
-val ZioLoggingVersion = "2.1.2"
+val ZioLoggingVersion = "2.1.5"
 val ZioSchemaVersion  = "0.2.1"
 
 name := "zio-jdbc"
@@ -73,7 +73,7 @@ lazy val examples = project
   .settings(
     publish / skip := true,
     libraryDependencies ++= Seq(
-      "ch.qos.logback"       % "logback-classic"          % "1.2.6",
-      "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
+      "ch.qos.logback"       % "logback-classic"          % "1.4.5",
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.2"
     )
   )

--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -720,7 +720,7 @@ trait JdbcDecoderLowPriorityImplicits {
   private[jdbc] def createRemapTable(schema: Schema[_]): String => String =
     schema match {
       case record: Schema.Record[_] =>
-        val recordNames = record.structure.map(field => (field.label.toLowerCase, field.label)).toMap
+        val recordNames = record.fields.map(field => (field.name.toLowerCase, field.name)).toMap
 
         columnName => recordNames.getOrElse(columnName.toLowerCase, columnName)
 
@@ -780,9 +780,8 @@ trait JdbcDecoderLowPriorityImplicits {
 
             case SqlTypes.DATE =>
               val date      = resultSet.getDate(columnIndex)
-              val formatter = DateTimeFormatter.ISO_DATE
 
-              DynamicValue.Primitive(date.toLocalDate(), StandardType.LocalDateType(formatter))
+              DynamicValue.Primitive(date.toLocalDate(), StandardType.LocalDateType)
 
             case SqlTypes.DECIMAL =>
               val bigDecimal = resultSet.getBigDecimal(columnIndex)
@@ -865,32 +864,24 @@ trait JdbcDecoderLowPriorityImplicits {
             case SqlTypes.TIME =>
               val time = resultSet.getTime(columnIndex)
 
-              val formatter = DateTimeFormatter.ISO_TIME
-
-              DynamicValue.Primitive(time.toLocalTime(), StandardType.LocalTimeType(formatter))
+              DynamicValue.Primitive(time.toLocalTime(), StandardType.LocalTimeType)
 
             case SqlTypes.TIMESTAMP =>
               val timestamp = resultSet.getTimestamp(columnIndex)
 
-              val formatter = DateTimeFormatter.ISO_INSTANT
-
-              DynamicValue.Primitive(timestamp.toInstant(), StandardType.InstantType(formatter))
+              DynamicValue.Primitive(timestamp.toInstant(), StandardType.InstantType)
 
             case SqlTypes.TIMESTAMP_WITH_TIMEZONE =>
               // TODO: Timezone
               val timestamp = resultSet.getTimestamp(columnIndex)
 
-              val formatter = DateTimeFormatter.ISO_INSTANT
-
-              DynamicValue.Primitive(timestamp.toInstant(), StandardType.InstantType(formatter))
+              DynamicValue.Primitive(timestamp.toInstant(), StandardType.InstantType)
 
             case SqlTypes.TIME_WITH_TIMEZONE =>
               // TODO: Timezone
               val time = resultSet.getTime(columnIndex)
 
-              val formatter = DateTimeFormatter.ISO_TIME
-
-              DynamicValue.Primitive(time.toLocalTime(), StandardType.LocalTimeType(formatter))
+              DynamicValue.Primitive(time.toLocalTime(), StandardType.LocalTimeType)
 
             case SqlTypes.TINYINT =>
               val short = resultSet.getShort(columnIndex)

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -646,12 +646,13 @@ trait JdbcEncoderLowPriorityImplicits { self =>
   //scalafmt: { maxColumn = 325, optIn.configStyleArguments = false }
   def fromSchema[A](implicit schema: Schema[A]): JdbcEncoder[A] =
     schema match {
-      case Schema.Primitive(standardType, _)                                                                                                                                                                                                                                                 =>
+      case Schema.Primitive(standardType, _) =>
         primitiveCodec(standardType)
-      case Schema.Optional(schema, _)                                                                                                                                                                                                                                                        =>
+      case Schema.Optional(schema, _)        =>
         JdbcEncoder.optionEncoder(self.fromSchema(schema))
-      case Schema.Tuple2(left, right, _)                                                                                                                                                                                                                                                      =>
+      case Schema.Tuple2(left, right, _)     =>
         JdbcEncoder.tuple2Encoder(self.fromSchema(left), self.fromSchema(right))
+      // format: off
       case x@(
         _: Schema.CaseClass1[_, _] |
         _: Schema.CaseClass2[_, _, _] |
@@ -676,8 +677,9 @@ trait JdbcEncoderLowPriorityImplicits { self =>
         _: Schema.CaseClass21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
         _: Schema.CaseClass22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]
         ) =>
+        // format: on
         caseClassEncoder(x.asInstanceOf[Schema.Record[A]].fields)
-      case _                                                                                                                                                                                                                                                                                 =>
+      case _                                 =>
         throw JdbcEncoderError(s"Failed to encode schema ${schema}", new IllegalArgumentException)
     }
 

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -650,60 +650,41 @@ trait JdbcEncoderLowPriorityImplicits { self =>
         primitiveCodec(standardType)
       case Schema.Optional(schema, _)                                                                                                                                                                                                                                                        =>
         JdbcEncoder.optionEncoder(self.fromSchema(schema))
-      case Schema.Tuple(left, right, _)                                                                                                                                                                                                                                                      =>
+      case Schema.Tuple2(left, right, _)                                                                                                                                                                                                                                                      =>
         JdbcEncoder.tuple2Encoder(self.fromSchema(left), self.fromSchema(right))
-      case Schema.CaseClass1(_, f, _, ext, _)                                                                                                                                                                                                                                                =>
-        caseClassEncoder(f -> ext)
-      case Schema.CaseClass2(_, f1, f2, _, ext1, ext2, _)                                                                                                                                                                                                                                    =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2)
-      case Schema.CaseClass3(_, f1, f2, f3, _, ext1, ext2, ext3, _)                                                                                                                                                                                                                          =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3)
-      case Schema.CaseClass4(_, f1, f2, f3, f4, _, ext1, ext2, ext3, ext4, _)                                                                                                                                                                                                                =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4)
-      case Schema.CaseClass5(_, f1, f2, f3, f4, f5, _, ext1, ext2, ext3, ext4, ext5, _)                                                                                                                                                                                                      =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5)
-      case Schema.CaseClass6(_, f1, f2, f3, f4, f5, f6, _, ext1, ext2, ext3, ext4, ext5, ext6, _)                                                                                                                                                                                            =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6)
-      case Schema.CaseClass7(_, f1, f2, f3, f4, f5, f6, f7, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, _)                                                                                                                                                                                  =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7)
-      case Schema.CaseClass8(_, f1, f2, f3, f4, f5, f6, f7, f8, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, _)                                                                                                                                                                        =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8)
-      case Schema.CaseClass9(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, _)                                                                                                                                                              =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9)
-      case Schema.CaseClass10(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, _)                                                                                                                                                 =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10)
-      case Schema.CaseClass11(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, _)                                                                                                                                     =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11)
-      case Schema.CaseClass12(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, _)                                                                                                                         =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12)
-      case Schema.CaseClass13(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, _)                                                                                                             =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13)
-      case Schema.CaseClass14(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, _)                                                                                                 =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14)
-      case Schema.CaseClass15(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, _)                                                                                     =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15)
-      case Schema.CaseClass16(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, _)                                                                         =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16)
-      case Schema.CaseClass17(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, _)                                                             =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17)
-      case Schema.CaseClass18(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, _)                                                 =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18)
-      case Schema.CaseClass19(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, _)                                     =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19)
-      case Schema.CaseClass20(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, _)                         =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20)
-      case Schema.CaseClass21(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, _)             =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21)
-      case Schema.CaseClass22(_, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, _, ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9, ext10, ext11, ext12, ext13, ext14, ext15, ext16, ext17, ext18, ext19, ext20, ext21, ext22, _) =>
-        caseClassEncoder(f1 -> ext1, f2 -> ext2, f3 -> ext3, f4 -> ext4, f5 -> ext5, f6 -> ext6, f7 -> ext7, f8 -> ext8, f9 -> ext9, f10 -> ext10, f11 -> ext11, f12 -> ext12, f13 -> ext13, f14 -> ext14, f15 -> ext15, f16 -> ext16, f17 -> ext17, f18 -> ext18, f19 -> ext19, f20 -> ext20, f21 -> ext21, f22 -> ext22)
+      case x@(
+        _: Schema.CaseClass1[_, _] |
+        _: Schema.CaseClass2[_, _, _] |
+        _: Schema.CaseClass3[_, _, _, _] |
+        _: Schema.CaseClass4[_, _, _, _, _] |
+        _: Schema.CaseClass5[_, _, _, _, _, _] |
+        _: Schema.CaseClass6[_, _, _, _, _, _, _] |
+        _: Schema.CaseClass7[_, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass8[_, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass9[_, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass10[_, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass11[_, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass12[_, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass13[_, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass14[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass18[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass20[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
+        _: Schema.CaseClass22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]
+        ) =>
+        caseClassEncoder(x.fields)
       case _                                                                                                                                                                                                                                                                                 =>
         throw JdbcEncoderError(s"Failed to encode schema ${schema}", new IllegalArgumentException)
     }
 
-  private[jdbc] def caseClassEncoder[A](fields: (Schema.Field[_], A => Any)*): JdbcEncoder[A] = { (a: A) =>
-    fields.map { case (Schema.Field(_, schema, _, _), extractor) =>
-      val encoder = self.fromSchema(schema).asInstanceOf[JdbcEncoder[Any]]
-      encoder.encode(extractor(a))
+  private[jdbc] def caseClassEncoder[A](fields: Chunk[Schema.Field[A, _]]): JdbcEncoder[A] = { (a: A) =>
+    fields.map { f =>
+      val encoder = self.fromSchema(f.schema)
+      encoder.encode(f.get(a))
     }.reduce(_ ++ Sql.comma ++ _)
   }
 }

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -676,14 +676,14 @@ trait JdbcEncoderLowPriorityImplicits { self =>
         _: Schema.CaseClass21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] |
         _: Schema.CaseClass22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _]
         ) =>
-        caseClassEncoder(x.fields)
+        caseClassEncoder(x.asInstanceOf[Schema.Record[A]].fields)
       case _                                                                                                                                                                                                                                                                                 =>
         throw JdbcEncoderError(s"Failed to encode schema ${schema}", new IllegalArgumentException)
     }
 
   private[jdbc] def caseClassEncoder[A](fields: Chunk[Schema.Field[A, _]]): JdbcEncoder[A] = { (a: A) =>
     fields.map { f =>
-      val encoder = self.fromSchema(f.schema)
+      val encoder = self.fromSchema(f.schema.asInstanceOf[Schema[Any]])
       encoder.encode(f.get(a))
     }.reduce(_ ++ Sql.comma ++ _)
   }

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -702,7 +702,7 @@ trait JdbcEncoderLowPriorityImplicits { self =>
 
   private[jdbc] def caseClassEncoder[A](fields: (Schema.Field[_], A => Any)*): JdbcEncoder[A] = { (a: A) =>
     fields.map { case (Schema.Field(_, schema, _, _), extractor) =>
-      val encoder = self.fromSchema(schema)
+      val encoder = self.fromSchema(schema).asInstanceOf[JdbcEncoder[Any]]
       encoder.encode(extractor(a))
     }.reduce(_ ++ Sql.comma ++ _)
   }

--- a/core/src/main/scala/zio/jdbc/ZConnectionPoolConfig.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnectionPoolConfig.scala
@@ -47,12 +47,24 @@ object ZConnectionPoolConfig {
   implicit val schema: Schema.CaseClass3[Int, Int, Duration, ZConnectionPoolConfig] =
     Schema.CaseClass3[Int, Int, Duration, ZConnectionPoolConfig](
       TypeId.parse(classOf[ZConnectionPoolConfig].getName),
-      Field("minConnections", Schema[Int]),
-      Field("maxConnections", Schema[Int]),
-      Field("timeToLive", Schema.Primitive(StandardType.DurationType)),
+      Field(
+        "minConnections",
+        Schema[Int],
+        get0 = _.minConnections,
+        set0 = (c, x) => c.copy(minConnections = x)
+      ),
+      Field(
+        "maxConnections",
+        Schema[Int],
+        get0 = _.maxConnections,
+        set0 = (c, x) => c.copy(maxConnections = x)
+      ),
+      Field(
+        "timeToLive",
+        Schema.Primitive(StandardType.DurationType),
+        get0 = _.timeToLive,
+        set0 = (c, x) => c.copy(timeToLive = x)
+      ),
       (min, max, ttl) => ZConnectionPoolConfig(min, max, defaultRetryPolicy, ttl),
-      _.minConnections,
-      _.maxConnections,
-      _.timeToLive
     )
 }

--- a/core/src/test/scala-2/zio/jdbc/model/CommentType.scala
+++ b/core/src/test/scala-2/zio/jdbc/model/CommentType.scala
@@ -1,0 +1,7 @@
+package zio.jdbc.model
+
+sealed trait CommentType
+object CommentType {
+  case object normal extends CommentType
+  case object reply extends CommentType
+}

--- a/core/src/test/scala-3/zio/jdbc/model/CommentType.scala
+++ b/core/src/test/scala-3/zio/jdbc/model/CommentType.scala
@@ -1,0 +1,5 @@
+package zio.jdbc.model
+
+enum CommentType {
+  case normal, reply
+}

--- a/core/src/test/scala/zio/jdbc/IsSqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/IsSqlFragmentSpec.scala
@@ -34,7 +34,10 @@ object IsSqlFragmentSpec extends ZIOSpecDefault {
           """
           }
 
-          assertZIO(result)(isLeft(startsWithString("This method can only be invoked on a fragment of SQL")))
+          assertZIO(result)(isLeft(
+            startsWithString("This method can only be invoked on a fragment of SQL") ||
+            startsWithString("Reporting of compilation error messages on Scala 3 is not currently supported")
+          ))
         }
     }
 }

--- a/core/src/test/scala/zio/jdbc/SqlSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlSpec.scala
@@ -209,45 +209,35 @@ object Models {
   implicit val personSchema: Schema[Person] =
     Schema.CaseClass2[String, Int, Person](
       TypeId.parse(classOf[Person].getName),
-      Field("name", Schema[String]),
-      Field("age", Schema[Int]),
-      (name, age) => Person(name, age),
-      _.name,
-      _.age
+      Field("name", Schema[String], get0 = _.name, set0 = (x, v) => x.copy(name = v)),
+      Field("age", Schema[Int], get0 = _.age, set0 = (x, v) => x.copy(age = v)),
+      Person.apply
     )
 
   implicit val userLoginSchema: Schema[UserLogin] =
     Schema.CaseClass2[String, String, UserLogin](
       TypeId.parse(classOf[UserLogin].getName),
-      Field("username", Schema[String]),
-      Field("password", Schema[String]),
-      (username, password) => UserLogin(username, password),
-      _.username,
-      _.password
+      Field("username", Schema[String], get0 = _.username, set0 = (x, v) => x.copy(username = v)),
+      Field("password", Schema[String], get0 = _.password, set0 = (x, v) => x.copy(password = v)),
+      UserLogin.apply
     )
 
   implicit val activeUser: Schema[ActiveUser] =
     Schema.CaseClass3[Person, UserLogin, Boolean, ActiveUser](
       TypeId.parse(classOf[ActiveUser].getName),
-      Field("person", Schema[Person]),
-      Field("login", Schema[UserLogin]),
-      Field("isActive", Schema[Boolean]),
-      (person, login, isActive) => ActiveUser(person, login, isActive),
-      _.person,
-      _.login,
-      _.isActive
+      Field("person", Schema[Person], get0 = _.person, set0 = (x, v) => x.copy(person = v)),
+      Field("login", Schema[UserLogin], get0 = _.login, set0 = (x, v) => x.copy(login = v)),
+      Field("isActive", Schema[Boolean], get0 = _.isActive, set0 = (x, v) => x.copy(isActive = v)),
+      ActiveUser.apply
     )
 
   implicit val transaction: Schema[Transfer] =
     Schema.CaseClass3[Long, Double, Option[String], Transfer](
       TypeId.parse(classOf[Transfer].getName),
-      Field("id", Schema[Long]),
-      Field("amount", Schema[Double]),
-      Field("location", Schema[Option[String]]),
-      (id, amount, location) => Transfer(id, amount, location),
-      _.id,
-      _.amount,
-      _.location
+      Field("id", Schema[Long], get0 = _.id, set0 = (x, v) => x.copy(id = v)),
+      Field("amount", Schema[Double], get0 = _.amount, set0 = (x, v) => x.copy(amount = v)),
+      Field("location", Schema[Option[String]], get0 = _.location, set0 = (x, v) => x.copy(location = v)),
+      Transfer.apply
     )
 
   implicit val personEncoder: JdbcEncoder[Person]         = JdbcEncoder.fromSchema[Person]

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -31,11 +31,9 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
     implicit val schema: Schema[Person] =
       Schema.CaseClass2[String, Int, Person](
         TypeId.parse(classOf[Person].getName),
-        Field("name", Schema[String]),
-        Field("age", Schema[Int]),
-        (name, age) => Person(name, age),
-        _.name,
-        _.age
+        Field("name", Schema[String], get0 = _.name, set0 = (x, v) => x.copy(name = v)),
+        Field("age", Schema[Int], get0 = _.age, set0 = (x, v) => x.copy(age = v)),
+        Person.apply
       )
   }
   val sherlockHolmes: User = User("Sherlock Holmes", 42)

--- a/examples/src/main/scala/zio/jdbc/examples/App.scala
+++ b/examples/src/main/scala/zio/jdbc/examples/App.scala
@@ -63,11 +63,9 @@ object User {
   implicit val schema: Schema[User] =
     Schema.CaseClass2[String, Int, User](
       TypeId.parse(classOf[User].getName),
-      Field("name", Schema[String]),
-      Field("age", Schema[Int]),
-      (name, age) => User(name, age),
-      _.name,
-      _.age
+      Field("name", Schema[String], get0 = _.name, set0 = (x, v) => x.copy(name = v)),
+      Field("age", Schema[Int], get0 = _.age, set0 = (x, v) => x.copy(age = v)),
+      User.apply
     )
 
   // One can derive a jdbc codec from a zio-schema or

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -23,7 +23,7 @@ object BuildHelper {
   lazy val Scala212: String = versions("2.12")
   lazy val Scala213: String = versions("2.13")
 
-  val SilencerVersion = "1.7.7"
+  val SilencerVersion = "1.7.12"
 
   private val stdOptions = Seq(
     "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("ch.epfl.scala"      % "sbt-bloop"                 % "1.4.10")
-addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"              % "0.9.31")
+addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"              % "0.10.4")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"             % "0.10.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"                % "0.4.3")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"            % "1.5.10")


### PR DESCRIPTION
Also:
+ Add test cases
+ Add `"zio-schema-derivation" % Test` dependency

Note: This PR is based on #85 - please merge that PR first