### PR TITLE
ZConnection.executeSqlWith to use setObject as fallback

### DIFF
--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -73,7 +73,7 @@ final class ZConnection(private[jdbc] val connection: Connection) extends AnyVal
               case v: java.sql.Timestamp    => statement.setTimestamp(paramIndex, v)
               case v: Boolean               => statement.setBoolean(paramIndex, v)
               case v: Float                 => statement.setFloat(paramIndex, v)
-              case v                        => statement.setString(paramIndex, v.toString)
+              case v                        => statement.setObject(paramIndex, v)
             }
 
             paramIndex += 1


### PR DESCRIPTION
Fixes issue inserting with a `UUID ` column, but i think it should work with other types.
```
timestamp=2023-01-23T03:20:16.082152Z level=ERROR thread=#zio-fiber-126 message="Error executing SQL due to: Exception in thread "zio-fiber-126" org.postgresql.util.PSQLException: ERROR: column "id" is of type uuid but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 71
```