### PR TITLE
Update installation.md. Version should be String

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ title: "Installation"
 _ZIO JDBC_ is available via Maven so importing in `build.sbt` is sufficient:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-jdbc" % @VERSION@
+libraryDependencies += "dev.zio" %% "zio-jdbc" % "@VERSION@"
 ```
 
 ## Hello World


### PR DESCRIPTION
When we copy libraryDependencies line it should work.
`libraryDependencies += "dev.zio" %% "zio-jdbc" % 0.0.1` wasn't a valid 
Expected should be:
`libraryDependencies += "dev.zio" %% "zio-jdbc" % "0.0.1"`