### PR TITLE
Allow results of a single NULL-able column

### DIFF
--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -62,6 +62,9 @@ object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
   implicit val timeDecoder: JdbcDecoder[java.sql.Time]              = JdbcDecoder(_.getTime(1))
   implicit val timestampDecoder: JdbcDecoder[java.sql.Timestamp]    = JdbcDecoder(_.getTimestamp(1))
 
+  implicit def optionDecoder[A](implicit decoder: JdbcColumnDecoder[A]): JdbcDecoder[Option[A]] =
+    JdbcDecoder(rs => Option(decoder.unsafeDecode(1, rs)))
+
   implicit def tuple2Decoder[A, B](implicit
     a: JdbcColumnDecoder[A],
     b: JdbcColumnDecoder[B]


### PR DESCRIPTION
Like Tuple results, we need a way to create an Option[A] decoder given the decoder for A.