### PR TITLE
Add IN clause param interpolation

### DIFF
--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -113,7 +113,7 @@ sealed trait SqlFragment { self =>
       sql.append(syntax.value)
     } { param =>
       param.value match {
-        case iterable: IterableOnce[Any] =>
+        case iterable: Iterable[Any] =>
           iterable.iterator.foreach { item =>
             paramsBuilder += item.toString
           }

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -297,12 +297,12 @@ object SqlFragment {
     implicit val blobSetter: Setter[java.sql.Blob]    = forSqlType((ps, i, value) => ps.setBlob(i, value), Types.BLOB)
     implicit val sqlDateSetter: Setter[java.sql.Date] = forSqlType((ps, i, value) => ps.setDate(i, value), Types.DATE)
     implicit val sqlTimeSetter: Setter[java.sql.Time] = forSqlType((ps, i, value) => ps.setTime(i, value), Types.TIME)
-    
-    implicit def chunkSetter[A](implicit setter: Setter[A]): Setter[Chunk[A]] = iterableSetter[A, Chunk[A]]
-    implicit def listSetter[A](implicit setter: Setter[A]): Setter[List[A]] = iterableSetter[A, List[A]]
+
+    implicit def chunkSetter[A](implicit setter: Setter[A]): Setter[Chunk[A]]   = iterableSetter[A, Chunk[A]]
+    implicit def listSetter[A](implicit setter: Setter[A]): Setter[List[A]]     = iterableSetter[A, List[A]]
     implicit def vectorSetter[A](implicit setter: Setter[A]): Setter[Vector[A]] = iterableSetter[A, Vector[A]]
-    implicit def setSetter[A](implicit setter: Setter[A]): Setter[Set[A]] = iterableSetter[A, Set[A]]
-      
+    implicit def setSetter[A](implicit setter: Setter[A]): Setter[Set[A]]       = iterableSetter[A, Set[A]]
+
     private def iterableSetter[A, I <: Iterable[A]](implicit setter: Setter[A]): Setter[I] =
       forSqlType(
         (ps, i, iterable) =>

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -113,7 +113,7 @@ sealed trait SqlFragment { self =>
       sql.append(syntax.value)
     } { param =>
       param.value match {
-        case iterable: Iterable[Any] =>
+        case iterable: Iterable[_] =>
           iterable.iterator.foreach { item =>
             paramsBuilder += item.toString
           }

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -122,11 +122,11 @@ sealed trait SqlFragment { self =>
           )
 
         case array: Array[_] =>
-          array.iterator.foreach { item =>
+          array.foreach { item =>
             paramsBuilder += item.toString
           }
           sql.append(
-            Seq.fill(array.iterator.size)("?").mkString(",")
+            Seq.fill(array.length)("?").mkString(",")
           )
 
         case _ =>

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -297,8 +297,13 @@ object SqlFragment {
     implicit val blobSetter: Setter[java.sql.Blob]    = forSqlType((ps, i, value) => ps.setBlob(i, value), Types.BLOB)
     implicit val sqlDateSetter: Setter[java.sql.Date] = forSqlType((ps, i, value) => ps.setDate(i, value), Types.DATE)
     implicit val sqlTimeSetter: Setter[java.sql.Time] = forSqlType((ps, i, value) => ps.setTime(i, value), Types.TIME)
-
-    implicit def sqlIterableSetter[A](implicit setter: Setter[A]): Setter[Seq[A]] =
+    
+    implicit def chunkSetter[A](implicit setter: Setter[A]): Setter[Chunk[A]] = iterableSetter[A, Chunk[A]]
+    implicit def listSetter[A](implicit setter: Setter[A]): Setter[List[A]] = iterableSetter[A, List[A]]
+    implicit def vectorSetter[A](implicit setter: Setter[A]): Setter[Vector[A]] = iterableSetter[A, Vector[A]]
+    implicit def setSetter[A](implicit setter: Setter[A]): Setter[Set[A]] = iterableSetter[A, Set[A]]
+      
+    private def iterableSetter[A, I <: Iterable[A]](implicit setter: Setter[A]): Setter[I] =
       forSqlType(
         (ps, i, iterable) =>
           iterable.zipWithIndex.foreach { case (value, valueIdx) =>

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -143,11 +143,13 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                     "Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
                 )
               } + test("interpolation param is supported collection") {
-                def assertIn[A: Setter](collection: A) =
+                def assertIn[A: Setter](collection: A) = {
+                  println(sql"select name, age from users where id in ($collection)".toString)
                   assertTrue(
                     sql"select name, age from users where id in ($collection)".toString ==
                       "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
                   )
+                }
 
                 assertIn(Chunk(1, 2, 3)) &&
                 assertIn(List(1, 2, 3)) &&

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -1,7 +1,7 @@
 package zio.jdbc
 
 import zio.Chunk
-import zio.jdbc.Sql.Setter
+import zio.jdbc.SqlFragment.Setter
 import zio.jdbc.{ transaction => transact }
 import zio.schema.{ Schema, TypeId }
 import zio.test.Assertion._

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -152,7 +152,8 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                 assertIn(Chunk(1, 2, 3)) &&
                 assertIn(List(1, 2, 3)) &&
                 assertIn(Vector(1, 2, 3)) &&
-                assertIn(Set(1, 2, 3))
+                assertIn(Set(1, 2, 3)) &&
+                assertIn(Array(1, 2, 3))
               }
             } +
             test("not in") {

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -124,13 +124,29 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                   s"Sql(select name, age from users WHERE id = ?, $id)"
               )
             } +
-            test("in") {
-              assertTrue(
-                sql"select name, age from users where id"
-                  .in(1, 2, 3)
-                  .toString ==
-                  s"Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
-              )
+            suite("in") {
+              test("fragment method") {
+                assertTrue(
+                  sql"select name, age from users where id"
+                    .in(1, 2, 3)
+                    .toString ==
+                    s"Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
+                )
+              } + test("fragment method where param is iterable") {
+                val seq = Seq(1, 2, 3)
+                assertTrue(
+                  sql"select name, age from users where id"
+                    .in(seq)
+                    .toString ==
+                    s"Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
+                )
+              } + test("interpolation param is iterable") {
+                val seq = Seq(1, 2, 3)
+                assertTrue(
+                  sql"select name, age from users where id in ($seq)".toString ==
+                    s"Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                )
+              }
             } +
             test("not in") {
               assertTrue(

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -1,8 +1,9 @@
 package zio.jdbc
 
 import zio.Chunk
-import zio.jdbc.{transaction => transact}
-import zio.schema.{Schema, TypeId}
+import zio.jdbc.Sql.Setter
+import zio.jdbc.{ transaction => transact }
+import zio.schema.{ Schema, TypeId }
 import zio.test.Assertion._
 import zio.test._
 
@@ -141,30 +142,17 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                     .toString ==
                     "Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
                 )
-              } + test("interpolation param is Chunk") {
-                val collection = Chunk(1, 2, 3)
-                assertTrue(
-                  sql"select name, age from users where id in ($collection)".toString ==
-                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
-                )
-              } + test("interpolation param is List") {
-                val collection = List(1, 2, 3)
-                assertTrue(
-                  sql"select name, age from users where id in ($collection)".toString ==
-                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
-                )
-              } + test("interpolation param is Vector") {
-                val collection = Vector(1, 2, 3)
-                assertTrue(
-                  sql"select name, age from users where id in ($collection)".toString ==
-                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
-                )
-              } + test("interpolation param is Set") {
-                val collection = Set(1, 2, 3)
-                assertTrue(
-                  sql"select name, age from users where id in ($collection)".toString ==
-                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
-                )
+              } + test("interpolation param is supported collection") {
+                def assertIn[A: Setter](collection: A) =
+                  assertTrue(
+                    sql"select name, age from users where id in ($collection)".toString ==
+                      "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                  )
+
+                assertIn(Chunk(1, 2, 3)) &&
+                assertIn(List(1, 2, 3)) &&
+                assertIn(Vector(1, 2, 3)) &&
+                assertIn(Set(1, 2, 3))
               }
             } +
             test("not in") {

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -1,7 +1,8 @@
 package zio.jdbc
 
-import zio.jdbc.{ transaction => transact }
-import zio.schema.{ Schema, TypeId }
+import zio.Chunk
+import zio.jdbc.{transaction => transact}
+import zio.schema.{Schema, TypeId}
 import zio.test.Assertion._
 import zio.test._
 
@@ -130,7 +131,7 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                   sql"select name, age from users where id"
                     .in(1, 2, 3)
                     .toString ==
-                    s"Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
+                    "Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
                 )
               } + test("fragment method where param is iterable") {
                 val seq = Seq(1, 2, 3)
@@ -138,13 +139,31 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                   sql"select name, age from users where id"
                     .in(seq)
                     .toString ==
-                    s"Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
+                    "Sql(select name, age from users where id IN (?,?,?), 1, 2, 3)"
                 )
-              } + test("interpolation param is iterable") {
-                val seq = Seq(1, 2, 3)
+              } + test("interpolation param is Chunk") {
+                val collection = Chunk(1, 2, 3)
                 assertTrue(
-                  sql"select name, age from users where id in ($seq)".toString ==
-                    s"Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                  sql"select name, age from users where id in ($collection)".toString ==
+                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                )
+              } + test("interpolation param is List") {
+                val collection = List(1, 2, 3)
+                assertTrue(
+                  sql"select name, age from users where id in ($collection)".toString ==
+                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                )
+              } + test("interpolation param is Vector") {
+                val collection = Vector(1, 2, 3)
+                assertTrue(
+                  sql"select name, age from users where id in ($collection)".toString ==
+                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
+                )
+              } + test("interpolation param is Set") {
+                val collection = Set(1, 2, 3)
+                assertTrue(
+                  sql"select name, age from users where id in ($collection)".toString ==
+                    "Sql(select name, age from users where id in (?,?,?), 1, 2, 3)"
                 )
               }
             } +

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -242,7 +242,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                 } yield assertTrue(value == Chunk(sherlockHolmes, johnWatson))
               } +
               test("select all in") {
-                val namesToSearch = Seq(sherlockHolmes.name, johnDoe.name)
+                val namesToSearch = Chunk(sherlockHolmes.name, johnDoe.name)
 
                 def assertUsersFound[A: Setter](collection: A) =
                   for {
@@ -250,11 +250,11 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                                sql"select name, age from users where name IN ($collection)".query[User].selectAll
                              }
                   } yield assertTrue(
-                    users.map(_.name) == Chunk.from(namesToSearch)
+                    users.map(_.name) == namesToSearch
                   )
 
                 def asserttions =
-                  assertUsersFound(Chunk.from(namesToSearch)) &&
+                  assertUsersFound(namesToSearch) &&
                     assertUsersFound(namesToSearch.toList) &&
                     assertUsersFound(namesToSearch.toVector) &&
                     assertUsersFound(namesToSearch.toSet) &&

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -243,7 +243,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                                  sql"select name, age from users where name IN ($collection)".as[User]
                                }
                              }
-                  } yield assertTrue(users.contains(sherlockHolmes))
+                  } yield assertTrue(users == Chunk(sherlockHolmes))
 
                 def asserttions =
                   assertUsersFound(Chunk(sherlockHolmes.name))

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -249,7 +249,8 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                   assertUsersFound(Chunk(sherlockHolmes.name))
                 assertUsersFound(List(sherlockHolmes.name)) &&
                 assertUsersFound(Vector(sherlockHolmes.name)) &&
-                assertUsersFound(Set(sherlockHolmes.name))
+                assertUsersFound(Set(sherlockHolmes.name)) &&
+                assertUsersFound(Array(sherlockHolmes.name))
 
                 for {
                   _          <- createUsers *> insertSherlock *> insertWatson

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -246,11 +246,11 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                   } yield assertTrue(users == Chunk(sherlockHolmes))
 
                 def asserttions =
-                  assertUsersFound(Chunk(sherlockHolmes.name))
-                assertUsersFound(List(sherlockHolmes.name)) &&
-                assertUsersFound(Vector(sherlockHolmes.name)) &&
-                assertUsersFound(Set(sherlockHolmes.name)) &&
-                assertUsersFound(Array(sherlockHolmes.name))
+                  assertUsersFound(Chunk(sherlockHolmes.name)) &&
+                    assertUsersFound(List(sherlockHolmes.name)) &&
+                    assertUsersFound(Vector(sherlockHolmes.name)) &&
+                    assertUsersFound(Set(sherlockHolmes.name)) &&
+                    assertUsersFound(Array(sherlockHolmes.name))
 
                 for {
                   _          <- createUsers *> insertSherlock *> insertWatson

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -238,7 +238,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                 for {
                   _     <- createUsers *> insertSherlock *> insertWatson
                   value <- transaction {
-                             val names = Seq(sherlockHolmes.name, johnWatson.name)
+                             val names = List(sherlockHolmes.name, johnWatson.name)
                              selectAll {
                                sql"select name, age from users where name IN (${names})".as[User]
                              }

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -234,6 +234,17 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                            }
                 } yield assertTrue(value == Chunk(sherlockHolmes, johnWatson))
               } +
+              test("select all in") {
+                for {
+                  _     <- createUsers *> insertSherlock *> insertWatson
+                  value <- transaction {
+                             val names = Seq(sherlockHolmes.name, johnWatson.name)
+                             selectAll {
+                               sql"select name, age from users where name IN (${names})".as[User]
+                             }
+                           }
+                } yield assertTrue(value.contains(sherlockHolmes))
+              } +
               test("select stream") {
                 for {
                   _     <- createUsers *> insertSherlock *> insertWatson

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -1,7 +1,7 @@
 package zio.jdbc
 
 import zio._
-import zio.jdbc.Sql.Setter
+import zio.jdbc.SqlFragment.Setter
 import zio.schema._
 import zio.test.Assertion._
 import zio.test.TestAspect._
@@ -239,9 +239,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                 def assertUsersFound[A: Setter](collection: A) =
                   for {
                     users <- transaction {
-                               selectAll {
-                                 sql"select name, age from users where name IN ($collection)".as[User]
-                               }
+                               sql"select name, age from users where name IN ($collection)".query[User].selectAll
                              }
                   } yield assertTrue(users == Chunk(sherlockHolmes))
 

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -43,6 +43,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
 
   val sherlockHolmes: User = User("Sherlock Holmes", 42)
   val johnWatson: User     = User("John Watson", 40)
+  val johnDoe: User        = User("John Doe", 18)
 
   val user1: UserNoId = UserNoId("User 1", 3)
   val user2: UserNoId = UserNoId("User 2", 4)
@@ -87,6 +88,11 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
   val insertWatson: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
     transaction {
       sql"insert into users values (default, ${johnWatson.name}, ${johnWatson.age})".insert
+    }
+
+  val insertJohn: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
+    transaction {
+      sql"insert into users values (default, ${johnDoe.name}, ${johnDoe.age})".insert
     }
 
   val insertBatches: ZIO[ZConnectionPool, Throwable, Long] = transaction {
@@ -236,22 +242,26 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                 } yield assertTrue(value == Chunk(sherlockHolmes, johnWatson))
               } +
               test("select all in") {
+                val namesToSearch = Seq(sherlockHolmes.name, johnDoe.name)
+
                 def assertUsersFound[A: Setter](collection: A) =
                   for {
                     users <- transaction {
                                sql"select name, age from users where name IN ($collection)".query[User].selectAll
                              }
-                  } yield assertTrue(users == Chunk(sherlockHolmes))
+                  } yield assertTrue(
+                    users.map(_.name) == Chunk.from(namesToSearch)
+                  )
 
                 def asserttions =
-                  assertUsersFound(Chunk(sherlockHolmes.name)) &&
-                    assertUsersFound(List(sherlockHolmes.name)) &&
-                    assertUsersFound(Vector(sherlockHolmes.name)) &&
-                    assertUsersFound(Set(sherlockHolmes.name)) &&
-                    assertUsersFound(Array(sherlockHolmes.name))
+                  assertUsersFound(Chunk.from(namesToSearch)) &&
+                    assertUsersFound(namesToSearch.toList) &&
+                    assertUsersFound(namesToSearch.toVector) &&
+                    assertUsersFound(namesToSearch.toSet) &&
+                    assertUsersFound(namesToSearch.toArray)
 
                 for {
-                  _          <- createUsers *> insertSherlock *> insertWatson
+                  _          <- createUsers *> insertSherlock *> insertWatson *> insertJohn
                   testResult <- asserttions
                 } yield testResult
               } +


### PR DESCRIPTION
Adds `IN` clause param interpolation.

```scala
val collection = List(1, 2, 3)
sql"select name, age from users where id in ($collection)"
```

equals to `Sql(select name, age from users where id in (?,?,?), 1, 2, 3)`

/claim #104