### PR TITLE
Support custom JdbcEncoder when creating sql segment

### DIFF
--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -16,693 +16,271 @@
 package zio.jdbc
 
 import zio.Chunk
-import zio.jdbc.SqlFragment.{ Segment, Setter }
+import zio.jdbc.SqlFragment.{ Segment, values }
 import zio.schema.{ Schema, StandardType }
 
-import java.sql.PreparedStatement
+import java.sql.{ PreparedStatement, Types }
 
 /**
  * A type class that describes the ability to convert a value of type `A` into
  * a fragment of SQL. This is useful for forming SQL insert statements.
  */
-trait JdbcEncoder[A] {
+trait JdbcEncoder[-A] { self =>
   def encode(value: A): SqlFragment
-  val setter: Option[Setter[A]]
 
-  final def contramap[B](f: B => A): JdbcEncoder[B] = {
-    val that = this
+  /**
+   * Returns first index after encoder
+   */
+  def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int
+
+  /**
+   * Returns first index after encoder
+   */
+  def unsafeSetNull(ps: PreparedStatement, index: Int): Int
+
+  final def contramap[B](f: B => A): JdbcEncoder[B] =
     new JdbcEncoder[B] {
-      override def encode(value: B): SqlFragment = that.encode(f(value))
+      override def encode(value: B): SqlFragment =
+        self.encode(f(value))
 
-      override val setter: Option[Setter[B]] = that.setter.map(_.contramap(f))
+      override def unsafeSetValue(ps: PreparedStatement, index: Int, value: B): Int =
+        self.unsafeSetValue(ps, index, f(value))
+
+      override def unsafeSetNull(ps: PreparedStatement, index: Int): Int = self.unsafeSetNull(ps, index)
+
+      override def sql(a: B): String = "?"
     }
-  }
+
+  def sql(value: A): String
+  def prettyValuePrinter(value: A): String = value.toString
 }
 
 object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
-  def apply[A]()(implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
 
   /**
-   * Use caution when using this method. Returning interpolating string may result in SQL injection attacks
+   * Restrictions:
+   * - Placeholder must contain only one "?"
    */
-  def apply[A](onEncode: A => SqlFragment): JdbcEncoder[A] = new JdbcEncoder[A] {
-    override def encode(value: A): SqlFragment = onEncode(value)
+  def single[A](placeholder: String, valueToString: A => String): JdbcEncoder[A] = {
+    val questionMarkCount = placeholder.count(_ == '?')
+    if (questionMarkCount == 0) {
+      throw new IllegalArgumentException("Placeholder must contain one '?'")
+    }
+    if (questionMarkCount > 1) {
+      throw new IllegalArgumentException("Placeholder can contain only one '?'")
+    }
+    new JdbcEncoder[A] {
 
-    override val setter: Option[Setter[A]] = None
+      override def encode(value: A): SqlFragment =
+        SqlFragment(Chunk(SqlFragment.Segment.Syntax.apply(placeholder)))
+
+      override def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int = {
+        ps.setString(index, valueToString(value))
+        index + 1
+      }
+
+      override def unsafeSetNull(ps: PreparedStatement, index: Int): Int = {
+        ps.setNull(index, Types.VARCHAR)
+        index + 1
+      }
+
+      override def sql(value: A): String = placeholder
+
+      override def prettyValuePrinter(value: A): String = valueToString(value)
+    }
   }
+
+  def apply[A]()(implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
 
   def apply[A](
     onEncode: A => SqlFragment,
+    onSql: => String,
     onValue: (PreparedStatement, Int, A) => Unit,
     onNull: (PreparedStatement, Int) => Unit
-  ): JdbcEncoder[A] = new JdbcEncoder[A] {
-    override def encode(value: A): SqlFragment = onEncode(value)
+  ): JdbcEncoder[A] =
+    new JdbcEncoder[A] {
 
-    override val setter: Option[Setter[A]] = Some(new Setter[A] {
-      override def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Unit = onValue(ps, index, value)
+      override def encode(value: A): SqlFragment = onEncode(value)
 
-      override def unsafeSetNull(ps: PreparedStatement, index: Int): Unit = onNull(ps, index)
-    })
-  }
+      override def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int = {
+        onValue(ps, index, value)
+        index + 1
+      }
 
-  private def withSetter[A](implicit setter: Setter[A]): JdbcEncoder[A] =
-    apply(
-      value => SqlFragment(Chunk.apply(Segment.Param(value, setter.asInstanceOf[Setter[Any]]))),
-      setter.unsafeSetValue,
-      setter.unsafeSetNull
+      override def unsafeSetNull(ps: PreparedStatement, index: Int): Int = {
+        onNull(ps, index)
+        index + 1
+      }
+
+      override def sql(a: A): String = onSql
+    }
+
+  private def forSqlType[A](onValue: (PreparedStatement, Int, A) => Unit, sqlType: Int): JdbcEncoder[A] =
+    new JdbcEncoder[A] {
+
+      override def encode(value: A): SqlFragment = SqlFragment(
+        Chunk.apply(Segment.Param(value, this.asInstanceOf[JdbcEncoder[Any]]))
+      )
+
+      def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int = {
+        onValue(ps, index, value)
+        index + 1
+      }
+
+      def unsafeSetNull(ps: PreparedStatement, index: Int): Int = {
+        ps.setNull(index, sqlType)
+        index + 1
+      }
+
+      override def sql(a: A): String = "?"
+    }
+
+  private def forIterableSqlType[A, I](
+    iterator: I => Iterator[A],
+    sqlType: Int
+  )(implicit encoder: JdbcEncoder[A]): JdbcEncoder[I] =
+    new JdbcEncoder[I] {
+
+      override def encode(value: I): SqlFragment = SqlFragment(
+        Chunk.apply(Segment.Param(value, this.asInstanceOf[JdbcEncoder[Any]]))
+      )
+
+      def unsafeSetValue(ps: PreparedStatement, index: Int, value: I): Int =
+        iterator(value)
+          .foldLeft(index) { case (i, value) => encoder.unsafeSetValue(ps, i, value) }
+
+      def unsafeSetNull(ps: PreparedStatement, index: Int): Int = {
+        ps.setNull(index, sqlType)
+        index + 1
+      }
+
+      override def sql(a: I): String = iterator(a).map(_ => "?").mkString(",")
+
+      override def prettyValuePrinter(value: I): String = iterator(value)
+        .mkString(", ")
+    }
+
+  def other[A](onValue: (PreparedStatement, Int, A) => Unit, sqlType: String): JdbcEncoder[A] = new JdbcEncoder[A] {
+
+    override def encode(value: A): SqlFragment = SqlFragment(
+      Chunk.apply(Segment.Param(value, this.asInstanceOf[JdbcEncoder[Any]]))
     )
 
-  implicit val intEncoder: JdbcEncoder[Int]                               = withSetter
-  implicit val longEncoder: JdbcEncoder[Long]                             = withSetter
-  implicit val doubleEncoder: JdbcEncoder[Double]                         = withSetter
-  implicit val charEncoder: JdbcEncoder[Char]                             = withSetter
-  implicit val stringEncoder: JdbcEncoder[String]                         = withSetter
-  implicit val booleanEncoder: JdbcEncoder[Boolean]                       = withSetter
-  implicit val bigIntEncoder: JdbcEncoder[java.math.BigInteger]           = withSetter
-  implicit val bigDecimalEncoder: JdbcEncoder[java.math.BigDecimal]       = withSetter
-  implicit val bigDecimalEncoderScala: JdbcEncoder[scala.math.BigDecimal] = withSetter
-  implicit val shortEncoder: JdbcEncoder[Short]                           = withSetter
-  implicit val floatEncoder: JdbcEncoder[Float]                           = withSetter
-  implicit val byteEncoder: JdbcEncoder[Byte]                             = withSetter
-  implicit val byteArrayEncoder: JdbcEncoder[Array[Byte]]                 = withSetter
-  implicit val byteChunkEncoder: JdbcEncoder[Chunk[Byte]]                 = withSetter
-  implicit val blobEncoder: JdbcEncoder[java.sql.Blob]                    = withSetter
-  implicit val uuidEncoder: JdbcEncoder[java.util.UUID]                   = withSetter
+    def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int = {
+      onValue(ps, index, value)
+      index + 1
+    }
 
-  private def optionParamSetter[A](implicit setter: Setter[A]): Setter[Option[A]]         =
-    Setter(
+    def unsafeSetNull(ps: PreparedStatement, index: Int): Int = {
+      ps.setNull(index, Types.OTHER, sqlType)
+      index + 1
+    }
+
+    override def sql(a: A): String = "?"
+  }
+
+  implicit def optionParamEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Option[A]] =
+    JdbcEncoder(
+      _.fold(SqlFragment.nullLiteral)(encoder.encode),
+      "?",
       (ps, i, value) =>
         value match {
-          case Some(value) => setter.unsafeSetValue(ps, i, value)
-          case None        => setter.unsafeSetNull(ps, i)
+          case Some(value) => encoder.unsafeSetValue(ps, i, value)
+          case None        => encoder.unsafeSetNull(ps, i)
         },
-      (ps, i) => setter.unsafeSetNull(ps, i)
+      (ps, i) => encoder.unsafeSetNull(ps, i)
     )
-  implicit def optionEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Option[A]] = new JdbcEncoder[Option[A]] {
-    override def encode(value: Option[A]): SqlFragment = value.fold(SqlFragment.nullLiteral)(encoder.encode)
 
-    override val setter: Option[Setter[Option[A]]] = encoder.setter.map(optionParamSetter(_))
-  }
+  implicit val intEncoder: JdbcEncoder[Int]               = forSqlType((ps, i, value) => ps.setInt(i, value), Types.INTEGER)
+  implicit val longEncoder: JdbcEncoder[Long]             = forSqlType((ps, i, value) => ps.setLong(i, value), Types.BIGINT)
+  implicit val doubleEncoder: JdbcEncoder[Double]         = forSqlType((ps, i, value) => ps.setDouble(i, value), Types.DOUBLE)
+  implicit val stringEncoder: JdbcEncoder[String]         = forSqlType((ps, i, value) => ps.setString(i, value), Types.VARCHAR)
+  implicit val booleanEncoder: JdbcEncoder[Boolean]       =
+    forSqlType((ps, i, value) => ps.setBoolean(i, value), Types.BOOLEAN)
+  implicit val shortEncoder: JdbcEncoder[Short]           = forSqlType((ps, i, value) => ps.setShort(i, value), Types.SMALLINT)
+  implicit val floatEncoder: JdbcEncoder[Float]           = forSqlType((ps, i, value) => ps.setFloat(i, value), Types.FLOAT)
+  implicit val byteEncoder: JdbcEncoder[Byte]             = forSqlType((ps, i, value) => ps.setByte(i, value), Types.TINYINT)
+  implicit val byteArrayEncoder: JdbcEncoder[Array[Byte]] =
+    forSqlType((ps, i, value) => ps.setBytes(i, value), Types.ARRAY)
+  implicit val blobEncoder: JdbcEncoder[java.sql.Blob]    = forSqlType((ps, i, value) => ps.setBlob(i, value), Types.BLOB)
+  implicit val sqlDateEncoder: JdbcEncoder[java.sql.Date] =
+    forSqlType((ps, i, value) => ps.setDate(i, value), Types.DATE)
+  implicit val sqlTimeEncoder: JdbcEncoder[java.sql.Time] =
+    forSqlType((ps, i, value) => ps.setTime(i, value), Types.TIME)
 
+  implicit def chunkEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Chunk[A]] = iterableEncoder[A, Chunk[A]]
+
+  implicit def listEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[List[A]] = iterableEncoder[A, List[A]]
+
+  implicit def vectorEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Vector[A]] =
+    iterableEncoder[A, Vector[A]]
+
+  implicit def setEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Set[A]] = iterableEncoder[A, Set[A]]
+
+  implicit def arrayEncoder[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[Array[A]] =
+    forIterableSqlType(
+      _.iterator,
+      Types.OTHER
+    )
+
+  private def iterableEncoder[A, I <: Iterable[A]](implicit encoder: JdbcEncoder[A]): JdbcEncoder[I] =
+    forIterableSqlType(
+      _.iterator,
+      Types.OTHER
+    )
+
+  implicit val bigDecimalEncoder: JdbcEncoder[java.math.BigDecimal] =
+    forSqlType((ps, i, value) => ps.setBigDecimal(i, value), Types.NUMERIC)
+  implicit val sqlTimestampEncoder: JdbcEncoder[java.sql.Timestamp] =
+    forSqlType((ps, i, value) => ps.setTimestamp(i, value), Types.TIMESTAMP)
+
+  implicit val uuidParamEncoder: JdbcEncoder[java.util.UUID] = other((ps, i, value) => ps.setObject(i, value), "uuid")
+
+  implicit val charEncoder: JdbcEncoder[Char]                             = stringEncoder.contramap(_.toString)
+  implicit val bigIntEncoder: JdbcEncoder[java.math.BigInteger]           =
+    bigDecimalEncoder.contramap(new java.math.BigDecimal(_))
+  implicit val bigDecimalScalaEncoder: JdbcEncoder[scala.math.BigDecimal] = bigDecimalEncoder.contramap(_.bigDecimal)
+  implicit val byteChunkEncoder: JdbcEncoder[Chunk[Byte]]                 = byteArrayEncoder.contramap(_.toArray)
+  implicit val instantEncoder: JdbcEncoder[java.time.Instant]             = sqlTimestampEncoder.contramap(java.sql.Timestamp.from)
+
+  // TODO: review for cases like Option of a tuple
   implicit def tuple2Encoder[A: JdbcEncoder, B: JdbcEncoder]: JdbcEncoder[(A, B)] =
-    JdbcEncoder(tuple => JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(tuple._2))
+    tupleNEncoder(JdbcEncoder[A](), JdbcEncoder[B]())
 
   implicit def tuple3Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder]: JdbcEncoder[(A, B, C)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3)
-    )
-
+    tupleNEncoder(JdbcEncoder[A](), JdbcEncoder[B](), JdbcEncoder[C]())
   implicit def tuple4Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder]
     : JdbcEncoder[(A, B, C, D)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      )
-    )
+    tupleNEncoder(JdbcEncoder[A](), JdbcEncoder[B](), JdbcEncoder[C](), JdbcEncoder[D]())
 
-  implicit def tuple5Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder, E: JdbcEncoder]
-    : JdbcEncoder[(A, B, C, D, E)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5)
-    )
+  private def tupleNEncoder[A <: Product](encoders: JdbcEncoder[_]*): JdbcEncoder[A] =
+    new JdbcEncoder[A] {
+      override def encode(value: A): SqlFragment =
+        SqlFragment.intersperse(
+          SqlFragment.comma,
+          value.productIterator
+            .zip(encoders)
+            .map { case (value, encoder) => encoder.asInstanceOf[JdbcEncoder[Any]].encode(value) }
+            .toSeq
+        )
 
-  implicit def tuple6Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      )
-    )
+      override def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int =
+        value.productIterator
+          .zip(encoders)
+          .foldLeft(index) { case (i, (value, encoder)) =>
+            encoder.asInstanceOf[JdbcEncoder[Any]].unsafeSetValue(ps, i, value)
+          }
 
-  implicit def tuple7Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7)
-    )
+      override def unsafeSetNull(ps: PreparedStatement, index: Int): Int =
+        encoders
+          .foldLeft(index) { case (i, encoder) =>
+            encoder.asInstanceOf[JdbcEncoder[Any]].unsafeSetNull(ps, i)
+          }
 
-  implicit def tuple8Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      )
-    )
+      override def sql(a: A): String = Seq.fill(encoders.size)("?").mkString(", ")
 
-  implicit def tuple9Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9)
-    )
-
-  implicit def tuple10Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      )
-    )
-
-  implicit def tuple11Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11)
-    )
-
-  implicit def tuple12Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      )
-    )
-
-  implicit def tuple13Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13)
-    )
-
-  implicit def tuple14Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      )
-    )
-
-  implicit def tuple15Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15)
-    )
-
-  implicit def tuple16Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      )
-    )
-
-  implicit def tuple17Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17)
-    )
-
-  implicit def tuple18Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder,
-    R: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
-        tuple._18
-      )
-    )
-
-  implicit def tuple19Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder,
-    R: JdbcEncoder,
-    S: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
-        tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19)
-    )
-
-  implicit def tuple20Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder,
-    R: JdbcEncoder,
-    S: JdbcEncoder,
-    T: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
-        tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
-        tuple._20
-      )
-    )
-
-  implicit def tuple21Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder,
-    R: JdbcEncoder,
-    S: JdbcEncoder,
-    T: JdbcEncoder,
-    U: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
-        tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
-        tuple._20
-      ) ++ SqlFragment.comma ++ JdbcEncoder[U]().encode(tuple._21)
-    )
-
-  implicit def tuple22Encoder[
-    A: JdbcEncoder,
-    B: JdbcEncoder,
-    C: JdbcEncoder,
-    D: JdbcEncoder,
-    E: JdbcEncoder,
-    F: JdbcEncoder,
-    G: JdbcEncoder,
-    H: JdbcEncoder,
-    I: JdbcEncoder,
-    J: JdbcEncoder,
-    K: JdbcEncoder,
-    L: JdbcEncoder,
-    M: JdbcEncoder,
-    N: JdbcEncoder,
-    O: JdbcEncoder,
-    P: JdbcEncoder,
-    Q: JdbcEncoder,
-    R: JdbcEncoder,
-    S: JdbcEncoder,
-    T: JdbcEncoder,
-    U: JdbcEncoder,
-    V: JdbcEncoder
-  ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
-    JdbcEncoder(tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
-        tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
-        tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
-        tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
-        tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
-        tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
-        tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
-        tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
-        tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
-        tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
-        tuple._20
-      ) ++ SqlFragment.comma ++ JdbcEncoder[U]().encode(tuple._21) ++ SqlFragment.comma ++ JdbcEncoder[V]().encode(
-        tuple._22
-      )
-    )
+      override def prettyValuePrinter(value: A): String = value.productIterator.mkString(", ")
+    }
 }
 
 trait JdbcEncoder0LowPriorityImplicits { self =>
@@ -719,7 +297,7 @@ trait JdbcEncoder0LowPriorityImplicits { self =>
       case StandardType.BigIntegerType => JdbcEncoder.bigIntEncoder
       case StandardType.BinaryType     => JdbcEncoder.byteChunkEncoder
       case StandardType.BigDecimalType => JdbcEncoder.bigDecimalEncoder
-      case StandardType.UUIDType       => JdbcEncoder.uuidEncoder
+      case StandardType.UUIDType       => JdbcEncoder.uuidParamEncoder
       // TODO: Standard Types which are missing are the date time types, not sure what would be the best way to handle them
       case _                           => throw JdbcEncoderError(s"Unsupported type: $standardType", new IllegalArgumentException)
     }
@@ -730,7 +308,7 @@ trait JdbcEncoder0LowPriorityImplicits { self =>
       case Schema.Primitive(standardType, _) =>
         primitiveCodec(standardType)
       case Schema.Optional(schema, _)        =>
-        JdbcEncoder.optionEncoder(self.fromSchema(schema))
+        JdbcEncoder.optionParamEncoder(self.fromSchema(schema))
       case Schema.Tuple2(left, right, _)     =>
         JdbcEncoder.tuple2Encoder(self.fromSchema(left), self.fromSchema(right))
       // format: off
@@ -764,11 +342,26 @@ trait JdbcEncoder0LowPriorityImplicits { self =>
         throw JdbcEncoderError(s"Failed to encode schema ${schema}", new IllegalArgumentException)
     }
 
-  private[jdbc] def caseClassEncoder[A](fields: Chunk[Schema.Field[A, _]]): JdbcEncoder[A] = JdbcEncoder(a =>
-    fields.map { f =>
-      val encoder = self.fromSchema(f.schema.asInstanceOf[Schema[Any]])
-      encoder.encode(f.get(a))
-    }.reduce(_ ++ SqlFragment.comma ++ _)
-  )
+  private[jdbc] def caseClassEncoder[A](fields: Chunk[Schema.Field[A, _]]): JdbcEncoder[A] = new JdbcEncoder[A] {
+    override def encode(a: A): SqlFragment =
+      fields.map { f =>
+        val encoder = self.fromSchema(f.schema.asInstanceOf[Schema[Any]])
+        encoder.encode(f.get(a))
+      }.reduce(_ ++ SqlFragment.comma ++ _)
+
+    override def unsafeSetValue(ps: PreparedStatement, index: Int, value: A): Int =
+      fields.foldLeft(index) { case (i, f) =>
+        val encoder = self.fromSchema(f.schema.asInstanceOf[Schema[Any]])
+        encoder.unsafeSetValue(ps, i, f.get(value))
+      }
+
+    override def unsafeSetNull(ps: PreparedStatement, index: Int): Int =
+      fields.foldLeft(index) { case (i, f) =>
+        val encoder = self.fromSchema(f.schema.asInstanceOf[Schema[Any]])
+        encoder.unsafeSetNull(ps, i)
+      }
+
+    override def sql(a: A): String = Seq.fill(fields.iterator.size)("?").mkString(",")
+  }
 
 }

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -21,6 +21,9 @@ import zio.schema.{ Schema, StandardType }
 /**
  * A type class that describes the ability to convert a value of type `A` into
  * a fragment of SQL. This is useful for forming SQL insert statements.
+ *
+ * NOTE: Users should be careful when creating custom JdbcEncoders for already existing types. You should either
+ * also create implicit Setter instance or use AnyVal wrapper (see `Custom JdbcEncoder` test).
  */
 trait JdbcEncoder[-A] {
   def encode(value: A): SqlFragment

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -208,10 +208,6 @@ object SqlFragment {
     final case class Param(value: Any, setter: Setter[Any]) extends Segment
     final case class Nested(sql: SqlFragment)               extends Segment
 
-    implicit def paramSegment[A](a: A)(implicit setter: Setter[A]): Segment.Param =
-      Segment.Param(a, setter.asInstanceOf[Setter[Any]])
-
-    implicit def nestedSqlSegment[A](sql: SqlFragment): Segment.Nested = Segment.Nested(sql)
   }
 
   trait Setter[A] { self =>

--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -46,7 +46,7 @@ final class ZConnection(private[jdbc] val connection: Connection) extends AnyVal
         _         <- ZIO.attempt {
                        var paramIndex = 1
                        sql.foreachSegment(_ => ()) { param =>
-                         param.setter.setValue(statement, paramIndex, param.value)
+                         param.setter.unsafeSetValue(statement, paramIndex, param.value)
                          paramIndex += 1
                        }
                      }

--- a/core/src/main/scala/zio/jdbc/package.scala
+++ b/core/src/main/scala/zio/jdbc/package.scala
@@ -15,12 +15,9 @@
  */
 package zio
 
-import zio.jdbc.SqlFragment.{ Segment, Setter }
-import zio.jdbc.{ JdbcEncoder, SqlFragment }
-
 import scala.language.implicitConversions
 
-package object jdbc extends LowPriorityImplicits1 {
+package object jdbc {
 
   implicit def sqlInterpolator(sc: StringContext): SqlInterpolator = new SqlInterpolator(sc)
 
@@ -36,16 +33,4 @@ package object jdbc extends LowPriorityImplicits1 {
   val transaction: ZLayer[ZConnectionPool, Throwable, ZConnection] =
     ZLayer(ZIO.serviceWith[ZConnectionPool](_.transaction)).flatten
 
-}
-trait LowPriorityImplicits1 extends LowPriorityImplicits2 {
-
-  implicit def paramSegment[A](a: A)(implicit setter: Setter[A]): Segment.Param =
-    Segment.Param(a, setter.asInstanceOf[Setter[Any]])
-
-  implicit def nestedSqlSegment[A](sql: SqlFragment): Segment.Nested = Segment.Nested(sql)
-}
-
-trait LowPriorityImplicits2 {
-  implicit def segmentFromJdbcEncoder[A](obj: A)(implicit encoder: JdbcEncoder[A]): Segment =
-    Segment.Nested(encoder.encode(obj))
 }

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -117,10 +117,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
     implicit val jdbcDecoder: JdbcDecoder[User] =
       JdbcDecoder[(String, Int)]().map[User](t => User(t._1, t._2))
 
-    implicit val jdbcEncoder: JdbcEncoder[User] = (value: User) => {
+    implicit val jdbcEncoder: JdbcEncoder[User] = JdbcEncoder { value =>
       val name = value.name
       val age  = value.age
-      sql"""${name}""" ++ ", " ++ s"${age}"
+      sql"""$name""" ++ ", " ++ s"$age"
     }
   }
 
@@ -130,10 +130,10 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
     implicit val jdbcDecoder: JdbcDecoder[UserNoId] =
       JdbcDecoder[(String, Int)]().map[UserNoId](t => UserNoId(t._1, t._2))
 
-    implicit val jdbcEncoder: JdbcEncoder[UserNoId] = (value: UserNoId) => {
+    implicit val jdbcEncoder: JdbcEncoder[UserNoId] = JdbcEncoder { value =>
       val name = value.name
       val age  = value.age
-      sql"""${name}""" ++ ", " ++ s"${age}"
+      sql"""$name""" ++ ", " ++ s"$age"
     }
   }
 


### PR DESCRIPTION
This PR allows JdbcEncoder to be used in sql interpolator using `Param.Nested`

Because they are a lot of issues regarding JdbcEncoder/Setter priority, I've added comment for users that want custom encoding for already existing types.

Fixes #83 
/claim #83