### PR TITLE
Fix NullPointerException when getClientInfo returns null

### DIFF
--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -302,7 +302,11 @@ object ZConnection {
           val _ = map.put(key, value)
         }
       }
-      properties.forEach(put(frozen))
+
+      if (properties != null) {
+        properties.forEach(put(frozen))
+      }
+
       frozen
     }
 

--- a/core/src/test/scala/zio/jdbc/ZConnectionSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionSpec.scala
@@ -40,6 +40,15 @@ object ZConnectionSpec extends ZIOSpecDefault {
               statementClosedTuple <- ZIO.succeed((res.preparedStatement, res.closedInScope))
             } yield assertTrue(statementClosedTuple._1.isClosed() && !statementClosedTuple._2)
           } //A bit of a hack, DummyException receives the prepared Statement so that its closed State can be checked outside ZConnection's Scope
+        } +
+        test("ZConnection Survives Null Client Info") {
+          val connection = new ZConnection(new ZConnection.Restorable({
+            val conn = new TestConnection
+            conn.setClientInfo(null)
+            conn
+          }))
+
+          assert(connection)(Assertion.anything)
         }
     } +
       suite("ZConnectionSpec LiveConnection") {


### PR DESCRIPTION
Sqlite JDBC driver (and perhaps other) returns `null` when `getClientInfo()` is called and this caused `NullPointerException` during creation of `ZConnection`. After this change this exception is not thrown anymore.

The provided test fails with previous version:

![Screenshot_20230706_191120](https://github.com/zio/zio-jdbc/assets/1381856/473c4c62-79d2-4f88-8a16-555a8af138c6)
