### PR TITLE
feat!: Add RETURNING clause

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,3 +77,20 @@ lazy val examples = project
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
     )
   )
+
+lazy val integration = project
+  .in(file("integration"))
+  .dependsOn(core)
+  .settings(
+    publish / skip := true,
+    Test / fork    := true,
+    libraryDependencies ++= Seq(
+      "org.testcontainers" % "postgresql"   % "1.19.0"   % Test,
+      "org.postgresql"     % "postgresql"   % "42.6.0"   % Test,
+      "dev.zio"           %% "zio-test"     % ZioVersion % Test,
+      "dev.zio"           %% "zio-test-sbt" % ZioVersion % Test,
+      "org.slf4j"          % "slf4j-api"    % "2.0.9"    % Test,
+      "org.slf4j"          % "slf4j-simple" % "2.0.9"    % Test
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+  )

--- a/core/src/main/scala/zio/jdbc/UpdateResult.scala
+++ b/core/src/main/scala/zio/jdbc/UpdateResult.scala
@@ -2,4 +2,4 @@ package zio.jdbc
 
 import zio.Chunk
 
-final case class UpdateResult(rowsUpdated: Long, updatedKeys: Chunk[Long])
+final case class UpdateResult[+A](rowsUpdated: Long, updatedKeys: Chunk[A])

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -65,17 +65,17 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
      """.execute
   }
 
-  val insertSherlock: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
+  val insertSherlock: ZIO[ZConnectionPool with Any, Throwable, UpdateResult[Long]] =
     transaction {
       sql"insert into users values (default, ${sherlockHolmes.name}, ${sherlockHolmes.age})".insertWithKeys
     }
 
-  val insertWatson: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
+  val insertWatson: ZIO[ZConnectionPool with Any, Throwable, UpdateResult[Long]] =
     transaction {
       sql"insert into users values (default, ${johnWatson.name}, ${johnWatson.age})".insertWithKeys
     }
 
-  val insertJohn: ZIO[ZConnectionPool with Any, Throwable, UpdateResult] =
+  val insertJohn: ZIO[ZConnectionPool with Any, Throwable, UpdateResult[Long]] =
     transaction {
       sql"insert into users values (default, ${johnDoe.name}, ${johnDoe.age})".insertWithKeys
     }

--- a/examples/src/main/scala/zio/jdbc/examples/App.scala
+++ b/examples/src/main/scala/zio/jdbc/examples/App.scala
@@ -14,7 +14,7 @@ object App extends ZIOAppDefault {
     Basic.ex0.execute
   }
 
-  val insertRow: ZIO[ZConnectionPool, Throwable, UpdateResult] = transaction {
+  val insertRow: ZIO[ZConnectionPool, Throwable, UpdateResult[Long]] = transaction {
     sql"insert into users (name, age)".values(sampleUser1, sampleUser2).insertWithKeys
   }
 

--- a/integration/src/test/scala/zio/jdbc/PgSpec.scala
+++ b/integration/src/test/scala/zio/jdbc/PgSpec.scala
@@ -1,0 +1,33 @@
+package zio.jdbc
+
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.PostgreSQLContainerProvider
+import zio.ZLayer
+import zio.ZIO
+import zio.test.ZIOSpec
+
+abstract class PgSpec extends ZIOSpec[ZConnectionPool] {
+  def bootstrap: ZLayer[Any, Throwable, ZConnectionPool] =
+    (ZLayer.scoped {
+      ZIO.fromAutoCloseable {
+        ZIO.attemptBlocking {
+          val provider = new PostgreSQLContainerProvider
+          val db       = provider.newInstance()
+          db.start()
+          db.asInstanceOf[PostgreSQLContainer[Nothing]]
+        }
+      }
+    } ++ ZLayer.succeed(ZConnectionPoolConfig.default)) >>> ZLayer.service[PostgreSQLContainer[Nothing]].flatMap {
+      env =>
+        val pg = env.get
+        ZConnectionPool.postgres(
+          "localhost",
+          pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+          pg.getDatabaseName(),
+          Map(
+            "user"     -> pg.getUsername(),
+            "password" -> pg.getPassword()
+          )
+        )
+    }
+}

--- a/integration/src/test/scala/zio/jdbc/ReturningSpec.scala
+++ b/integration/src/test/scala/zio/jdbc/ReturningSpec.scala
@@ -1,0 +1,66 @@
+package zio.jdbc
+
+import zio.test._
+
+object ReturningSpec extends PgSpec {
+  case class User(name: String, age: Int)
+
+  object User {
+    implicit val jdbcDecoder: JdbcDecoder[User] =
+      JdbcDecoder[(String, Int)]().map((User.apply _).tupled)
+    implicit val jdbcEncoder: JdbcEncoder[User] =
+      JdbcEncoder[(String, Int)]().contramap(User.unapply(_).get)
+  }
+
+  val spec =
+    suite("Returning")(
+      test("Inserts returning rows") {
+        check(Gen.chunkOf1(Gen.alphaNumericString.map(_.take(40)).zip(Gen.int(10, 100)))) { tuples =>
+          val users = tuples.map((User.apply _).tupled).toChunk
+
+          for {
+            result <- transaction {
+                        (sql"""INSERT INTO users(name,age)""".values(users) ++ " RETURNING id, name, age")
+                          .insertReturning[(Int, String, Int)]
+                      }
+            _      <- transaction(sql"DELETE FROM users".delete)
+          } yield assert(result.rowsUpdated)(Assertion.equalTo(users.size.toLong)) &&
+            assert(result.updatedKeys.map(_._1).toSet)(Assertion.hasSameElements(result.updatedKeys.map(_._1)))
+        }
+      },
+      test("Updates returning rows") {
+        check(Gen.chunkOf1(Gen.alphaNumericString.map(_.take(40)).zip(Gen.int(10, 100)))) { tuples =>
+          val users = tuples.map((User.apply _).tupled).toChunk
+
+          for {
+            _      <- transaction {
+                        sql"""INSERT INTO users(name,age)""".values(users).execute
+                      }
+            result <- transaction {
+                        sql"""UPDATE users SET age = age * 2 RETURNING name, age""".updateReturning[User]
+                      }
+            _      <- transaction(sql"DELETE FROM users".delete)
+          } yield assert(result.rowsUpdated)(Assertion.equalTo(users.size.toLong)) &&
+            assert(result.updatedKeys)(Assertion.hasSameElements(users.map(u => u.copy(age = u.age * 2))))
+        }
+      } @@ TestAspect.samples(2),
+      test("Deletes returning rows") {
+        check(Gen.chunkOf1(Gen.alphaNumericString.map(_.take(40)).zip(Gen.int(10, 100)))) { tuples =>
+          val users = tuples.map((User.apply _).tupled).toChunk
+
+          for {
+            _      <- transaction {
+                        sql"""INSERT INTO users(name,age)""".values(users).execute
+                      }
+            result <- transaction {
+                        sql"""DELETE FROM users RETURNING name, age""".deleteReturning[User]
+                      }
+          } yield assert(result.rowsUpdated)(Assertion.equalTo(users.size.toLong)) &&
+            assert(result.updatedKeys)(Assertion.hasSameElements(users))
+        }
+      }
+    ) @@ TestAspect.sequential @@ TestAspect.around(
+      transaction(sql"CREATE TABLE users (id SERIAL, name VARCHAR(40), age INTEGER)".execute),
+      transaction(sql"DROP TABLE users".execute).orDie
+    )
+}


### PR DESCRIPTION
Most RDBMS support the ability of returning rows after an UPDATE/DELETE/INSERT statement.

This is quite useful to move computation inside the database and reduce the number of queries.
It also completely subsumes the ability to return created IDs from after INSERT statements.

So that is why I changed the `UpdateResult` datatype to hold any value and implemented the `insertWithKeys` in terms of the new `executeWithReturning`.

Also created an integration spec as I did not know if you wanted to launch containers inside GH actions, current output is:

```
[zio-default-blocking-1] INFO org.testcontainers.utility.ImageNameSubstitutor - Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
[zio-default-blocking-1] INFO org.testcontainers.dockerclient.DockerClientProviderStrategy - Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
[zio-default-blocking-1] INFO org.testcontainers.dockerclient.DockerClientProviderStrategy - Found Docker environment with Docker accessed via Unix socket (/Users/regiskuckaertz/.docker/run/docker.sock)
[zio-default-blocking-1] INFO org.testcontainers.DockerClientFactory - Docker host IP address is localhost
[zio-default-blocking-1] INFO org.testcontainers.DockerClientFactory - Connected to docker:
  Server Version: 24.0.5
  API Version: 1.43
  Operating System: Docker Desktop
  Total Memory: 7959 MB
[zio-default-blocking-1] INFO tc.testcontainers/ryuk:0.5.1 - Creating container for image: testcontainers/ryuk:0.5.1
[zio-default-blocking-1] INFO org.testcontainers.utility.RegistryAuthLocator - Credential helper/store (docker-credential-desktop) does not have credentials for https://index.docker.io/v1/
[zio-default-blocking-1] INFO tc.testcontainers/ryuk:0.5.1 - Container testcontainers/ryuk:0.5.1 is starting: f50814a76c487cd3f3a47f9c1a84f470c3f30a09705571a8bf80a2072bd53e59
[zio-default-blocking-1] INFO tc.testcontainers/ryuk:0.5.1 - Container testcontainers/ryuk:0.5.1 started in PT10.332311S
[zio-default-blocking-1] INFO org.testcontainers.utility.RyukResourceReaper - Ryuk started - will monitor and terminate Testcontainers containers on JVM exit
[zio-default-blocking-1] INFO org.testcontainers.DockerClientFactory - Checking the system...
[zio-default-blocking-1] INFO org.testcontainers.DockerClientFactory - ✔︎ Docker server version should be at least 1.6.0
[zio-default-blocking-1] INFO tc.postgres:9.6.12 - Creating container for image: postgres:9.6.12
[zio-default-blocking-1] INFO tc.postgres:9.6.12 - Container postgres:9.6.12 is starting: 19b6e4ae434f20f8853f9a20542b28b9be5b3b508052d777dd62fb4c1c803eb4
[zio-default-blocking-1] INFO tc.postgres:9.6.12 - Container postgres:9.6.12 started in PT4.605536S
[zio-default-blocking-1] INFO tc.postgres:9.6.12 - Container is started (JDBC URL: jdbc:postgresql://localhost:50131/test?loggerLevel=OFF)
+ Returning
  + Inserts returning rows
  + Updates returning rows
  + Deletes returning rows
timestamp=2023-09-09T12:04:35.174604Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-8" java.io.FileNotFoundException: target/test-reports-zio/output.json (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at scala.io.Source$.fromFile(Source.scala:94)
        at scala.io.Source$.fromFile(Source.scala:79)
        at scala.io.Source$.fromFile(Source.scala:57)
        at zio.test.results.ResultFileOpsJson$Live.$anonfun$removeLastComma$1(ResultFileOpsJson.scala:50)
        at zio.test.results.ResultFileOpsJson.Live.removeLastComma(ResultFileOpsJson.scala:50)
        at zio.test.results.ResultFileOpsJson.Live.closeJson(ResultFileOpsJson.scala:38)
        at zio.test.results.ResultFileOpsJson.Live.apply(ResultFileOpsJson.scala:82)"
```

(Is there a way to disable the production of that JSON report?)