### PR TITLE
Remove unnecessary parentheses from `JdbcDecoder`, `JdbcEncoder` and `Setter` summoners

### DIFF
--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -69,7 +69,7 @@ object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
     A.unsafeDecode(n, rs)._2
   }
 
-  def apply[A]()(implicit decoder: JdbcDecoder[A]): JdbcDecoder[A] = decoder
+  def apply[A](implicit decoder: JdbcDecoder[A]): JdbcDecoder[A] = decoder
 
   def apply[A](f: ResultSet => (Int => A), expected: String = "value"): JdbcDecoder[A] =
     new JdbcDecoder[A] {

--- a/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcEncoder.scala
@@ -29,7 +29,7 @@ trait JdbcEncoder[-A] {
 }
 
 object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
-  def apply[A]()(implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
+  def apply[A](implicit encoder: JdbcEncoder[A]): JdbcEncoder[A] = encoder
 
   implicit val intEncoder: JdbcEncoder[Int]                               = value => sql"$value"
   implicit val longEncoder: JdbcEncoder[Long]                             = value => sql"$value"
@@ -55,31 +55,31 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     value => value.fold(SqlFragment.nullLiteral)(encoder.encode)
 
   implicit def tuple2Encoder[A: JdbcEncoder, B: JdbcEncoder]: JdbcEncoder[(A, B)] =
-    tuple => JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(tuple._2)
+    tuple => JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(tuple._2)
 
   implicit def tuple3Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder]: JdbcEncoder[(A, B, C)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3)
 
   implicit def tuple4Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder]
     : JdbcEncoder[(A, B, C, D)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
       )
 
   implicit def tuple5Encoder[A: JdbcEncoder, B: JdbcEncoder, C: JdbcEncoder, D: JdbcEncoder, E: JdbcEncoder]
     : JdbcEncoder[(A, B, C, D, E)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5)
 
   implicit def tuple6Encoder[
     A: JdbcEncoder,
@@ -90,11 +90,11 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     F: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
       )
 
@@ -108,13 +108,13 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     G: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7)
 
   implicit def tuple8Encoder[
     A: JdbcEncoder,
@@ -127,13 +127,13 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     H: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
       )
 
@@ -149,15 +149,15 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     I: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9)
 
   implicit def tuple10Encoder[
     A: JdbcEncoder,
@@ -172,15 +172,15 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     J: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
       )
 
@@ -198,17 +198,17 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     K: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11)
 
   implicit def tuple12Encoder[
     A: JdbcEncoder,
@@ -225,17 +225,17 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     L: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
       )
 
@@ -255,19 +255,19 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     M: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13)
 
   implicit def tuple14Encoder[
     A: JdbcEncoder,
@@ -286,19 +286,19 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     N: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
       )
 
@@ -320,21 +320,21 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     O: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15)
 
   implicit def tuple16Encoder[
     A: JdbcEncoder,
@@ -355,21 +355,21 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     P: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
       )
 
@@ -393,23 +393,23 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     Q: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17)
 
   implicit def tuple18Encoder[
     A: JdbcEncoder,
@@ -432,23 +432,23 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     R: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R].encode(
         tuple._18
       )
 
@@ -474,25 +474,25 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     S: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R].encode(
         tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[S].encode(tuple._19)
 
   implicit def tuple20Encoder[
     A: JdbcEncoder,
@@ -517,25 +517,25 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     T: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R].encode(
         tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[S].encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T].encode(
         tuple._20
       )
 
@@ -563,27 +563,27 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     U: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R].encode(
         tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[S].encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T].encode(
         tuple._20
-      ) ++ SqlFragment.comma ++ JdbcEncoder[U]().encode(tuple._21)
+      ) ++ SqlFragment.comma ++ JdbcEncoder[U].encode(tuple._21)
 
   implicit def tuple22Encoder[
     A: JdbcEncoder,
@@ -610,27 +610,27 @@ object JdbcEncoder extends JdbcEncoder0LowPriorityImplicits {
     V: JdbcEncoder
   ]: JdbcEncoder[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
     tuple =>
-      JdbcEncoder[A]().encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B]().encode(
+      JdbcEncoder[A].encode(tuple._1) ++ SqlFragment.comma ++ JdbcEncoder[B].encode(
         tuple._2
-      ) ++ SqlFragment.comma ++ JdbcEncoder[C]().encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[C].encode(tuple._3) ++ SqlFragment.comma ++ JdbcEncoder[D].encode(
         tuple._4
-      ) ++ SqlFragment.comma ++ JdbcEncoder[E]().encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[E].encode(tuple._5) ++ SqlFragment.comma ++ JdbcEncoder[F].encode(
         tuple._6
-      ) ++ SqlFragment.comma ++ JdbcEncoder[G]().encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[G].encode(tuple._7) ++ SqlFragment.comma ++ JdbcEncoder[H].encode(
         tuple._8
-      ) ++ SqlFragment.comma ++ JdbcEncoder[I]().encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[I].encode(tuple._9) ++ SqlFragment.comma ++ JdbcEncoder[J].encode(
         tuple._10
-      ) ++ SqlFragment.comma ++ JdbcEncoder[K]().encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[K].encode(tuple._11) ++ SqlFragment.comma ++ JdbcEncoder[L].encode(
         tuple._12
-      ) ++ SqlFragment.comma ++ JdbcEncoder[M]().encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[M].encode(tuple._13) ++ SqlFragment.comma ++ JdbcEncoder[N].encode(
         tuple._14
-      ) ++ SqlFragment.comma ++ JdbcEncoder[O]().encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[O].encode(tuple._15) ++ SqlFragment.comma ++ JdbcEncoder[P].encode(
         tuple._16
-      ) ++ SqlFragment.comma ++ JdbcEncoder[Q]().encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[Q].encode(tuple._17) ++ SqlFragment.comma ++ JdbcEncoder[R].encode(
         tuple._18
-      ) ++ SqlFragment.comma ++ JdbcEncoder[S]().encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[S].encode(tuple._19) ++ SqlFragment.comma ++ JdbcEncoder[T].encode(
         tuple._20
-      ) ++ SqlFragment.comma ++ JdbcEncoder[U]().encode(tuple._21) ++ SqlFragment.comma ++ JdbcEncoder[V]().encode(
+      ) ++ SqlFragment.comma ++ JdbcEncoder[U].encode(tuple._21) ++ SqlFragment.comma ++ JdbcEncoder[V].encode(
         tuple._22
       )
 }

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -189,7 +189,7 @@ sealed trait SqlFragment { self =>
    * as values of type `A`.
    */
   def deleteReturning[A: JdbcDecoder]: ZIO[ZConnection, Throwable, UpdateResult[A]] =
-    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]()))
+    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]))
 
   /**
    * Performs an SQL insert query, returning a count of rows inserted.
@@ -202,7 +202,7 @@ sealed trait SqlFragment { self =>
    * as values of type `A`.
    */
   def insertReturning[A: JdbcDecoder]: ZIO[ZConnection, Throwable, UpdateResult[A]] =
-    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]()))
+    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]))
 
   /**
    * Performs an SQL insert query, returning a count of rows inserted and a
@@ -211,14 +211,14 @@ sealed trait SqlFragment { self =>
    * `Chunk.empty` is returned.
    */
   def insertWithKeys: ZIO[ZConnection, Throwable, UpdateResult[Long]] =
-    ZIO.scoped(executeWithReturning(self, JdbcDecoder[Long]()))
+    ZIO.scoped(executeWithReturning(self, JdbcDecoder[Long]))
 
   /**
    * Executes a SQL update query with a RETURNING clause, materialized
    * as values of type `A`.
    */
   def updateReturning[A: JdbcDecoder]: ZIO[ZConnection, Throwable, UpdateResult[A]] =
-    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]()))
+    ZIO.scoped(executeWithReturning(self, JdbcDecoder[A]))
 
   /**
    * Performs a SQL update query, returning a count of rows updated.
@@ -307,7 +307,7 @@ object SqlFragment {
   }
 
   object Setter {
-    def apply[A]()(implicit setter: Setter[A]): Setter[A] = setter
+    def apply[A](implicit setter: Setter[A]): Setter[A] = setter
 
     def apply[A](onValue: (PreparedStatement, Int, A) => Unit, onNull: (PreparedStatement, Int) => Unit): Setter[A] =
       new Setter[A] {

--- a/core/src/test/scala/zio/jdbc/QuerySpec.scala
+++ b/core/src/test/scala/zio/jdbc/QuerySpec.scala
@@ -10,7 +10,7 @@ object QuerySpec extends ZIOSpecDefault {
 
   object User {
     implicit val jdbcDecoder: JdbcDecoder[User] =
-      JdbcDecoder[(String, Int)]().map[User](t => User(t._1, t._2))
+      JdbcDecoder[(String, Int)].map[User](t => User(t._1, t._2))
 
     implicit val jdbcEncoder: JdbcEncoder[User] = (value: User) => {
       val name = value.name
@@ -71,7 +71,7 @@ object QuerySpec extends ZIOSpecDefault {
 
         object UserNoId {
           implicit val jdbcDecoder: JdbcDecoder[UserNoId] =
-            JdbcDecoder[(String, Int)]().map[UserNoId](t => UserNoId(t._1, t._2))
+            JdbcDecoder[(String, Int)].map[UserNoId](t => UserNoId(t._1, t._2))
 
           implicit val jdbcEncoder: JdbcEncoder[UserNoId] = (value: UserNoId) => {
             val name = value.name

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -46,7 +46,7 @@ object SqlFragmentSpec extends ZIOSpecDefault {
         } +
         test("type safe interpolation") {
           final case class Foo(value: String)
-          implicit val fooParamSetter: SqlFragment.Setter[Foo] = SqlFragment.Setter[String]().contramap(_.toString)
+          implicit val fooParamSetter: SqlFragment.Setter[Foo] = SqlFragment.Setter[String].contramap(_.toString)
 
           val testSql = sql"${Foo("test")}"
 
@@ -320,7 +320,7 @@ object SqlFragmentSpec extends ZIOSpecDefault {
 
               object UserNoId {
                 implicit val jdbcDecoder: JdbcDecoder[UserNoId] =
-                  JdbcDecoder[(String, Int)]().map[UserNoId](t => UserNoId(t._1, t._2))
+                  JdbcDecoder[(String, Int)].map[UserNoId](t => UserNoId(t._1, t._2))
 
                 implicit val jdbcEncoder: JdbcEncoder[UserNoId] = (value: UserNoId) => {
                   val name = value.name

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -108,7 +108,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
 
   object User {
     implicit val jdbcDecoder: JdbcDecoder[User] =
-      JdbcDecoder[(String, Int)]().map[User](t => User(t._1, t._2))
+      JdbcDecoder[(String, Int)].map[User](t => User(t._1, t._2))
 
     implicit val jdbcEncoder: JdbcEncoder[User] = (value: User) => {
       val name = value.name
@@ -121,7 +121,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
 
   object UserNoId {
     implicit val jdbcDecoder: JdbcDecoder[UserNoId] =
-      JdbcDecoder[(String, Int)]().map[UserNoId](t => UserNoId(t._1, t._2))
+      JdbcDecoder[(String, Int)].map[UserNoId](t => UserNoId(t._1, t._2))
 
     implicit val jdbcEncoder: JdbcEncoder[UserNoId] = (value: UserNoId) => {
       val name = value.name

--- a/integration/src/test/scala/zio/jdbc/ReturningSpec.scala
+++ b/integration/src/test/scala/zio/jdbc/ReturningSpec.scala
@@ -7,9 +7,9 @@ object ReturningSpec extends PgSpec {
 
   object User {
     implicit val jdbcDecoder: JdbcDecoder[User] =
-      JdbcDecoder[(String, Int)]().map((User.apply _).tupled)
+      JdbcDecoder[(String, Int)].map((User.apply _).tupled)
     implicit val jdbcEncoder: JdbcEncoder[User] =
-      JdbcEncoder[(String, Int)]().contramap(User.unapply(_).get)
+      JdbcEncoder[(String, Int)].contramap(User.unapply(_).get)
   }
 
   val spec =


### PR DESCRIPTION
To pass CI, this PR needs: 
- https://github.com/zio/zio-jdbc/pull/168