### PR TITLE
remove `Setter.arraySetter`

### DIFF
--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -356,15 +356,6 @@ object SqlFragment {
     implicit def vectorSetter[A](implicit setter: Setter[A]): Setter[Vector[A]] = iterableSetter[A, Vector[A]]
     implicit def setSetter[A](implicit setter: Setter[A]): Setter[Set[A]]       = iterableSetter[A, Set[A]]
 
-    implicit def arraySetter[A](implicit setter: Setter[A]): Setter[Array[A]] =
-      forSqlType(
-        (ps, i, iterable) =>
-          iterable.zipWithIndex.foreach { case (value, valueIdx) =>
-            setter.setValue(ps, i + valueIdx, value)
-          },
-        Types.OTHER
-      )
-
     private def iterableSetter[A, I <: Iterable[A]](implicit setter: Setter[A]): Setter[I] =
       forSqlType(
         (ps, i, iterable) =>

--- a/core/src/main/scala/zio/jdbc/ZConnection.scala
+++ b/core/src/main/scala/zio/jdbc/ZConnection.scala
@@ -52,11 +52,6 @@ final class ZConnection(private[jdbc] val underlying: ZConnection.Restorable) ex
                                                Seq.fill(iterable.iterator.size)("?").mkString(", ")
                                              )
 
-                                           case array: Array[_] =>
-                                             sb.append(
-                                               Seq.fill(array.length)("?").mkString(", ")
-                                             )
-
                                            case _ => sb.append("?")
                                          }
                                        }

--- a/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
+++ b/core/src/test/scala/zio/jdbc/SqlFragmentSpec.scala
@@ -158,8 +158,7 @@ object SqlFragmentSpec extends ZIOSpecDefault {
                 assertIn(Chunk(1, 2, 3)) &&
                 assertIn(List(1, 2, 3)) &&
                 assertIn(Vector(1, 2, 3)) &&
-                assertIn(Set(1, 2, 3)) &&
-                assertIn(Array(1, 2, 3))
+                assertIn(Set(1, 2, 3))
               }
             } +
             test("not in") {

--- a/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
+++ b/core/src/test/scala/zio/jdbc/ZConnectionPoolSpec.scala
@@ -294,8 +294,7 @@ object ZConnectionPoolSpec extends ZIOSpecDefault {
                   assertUsersFound(namesToSearch) &&
                     assertUsersFound(namesToSearch.toList) &&
                     assertUsersFound(namesToSearch.toVector) &&
-                    assertUsersFound(namesToSearch.toSet) &&
-                    assertUsersFound(namesToSearch.toArray)
+                    assertUsersFound(namesToSearch.toSet)
 
                 for {
                   _          <- createUsers *> insertSherlock *> insertWatson *> insertJohn


### PR DESCRIPTION
I want to interpolate in postgres arrays as parameters - not explode them as multiple parameters. It's basically impossible to implement support for  `Array` columns with this implicit present.

Other libraries like anorm and doobie have settled on this distinction already, scala sequences are exploded in the sql and `Array`s are passed right through (with the right typeclass instances, of course). I suggest we do the same for zio-jdbc.

This is of course a breaking change, but probably doesn't affect many people. The workaround will be to say `myArray.toList` or similar 