### PR TITLE
Make `intersperse` visible

### DIFF
--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -436,10 +436,7 @@ object SqlFragment {
   def update(table: String): SqlFragment =
     s"UPDATE $table"
 
-  private[jdbc] def intersperse(
-    sep: SqlFragment,
-    elements: Iterable[SqlFragment]
-  ): SqlFragment = {
+  def intersperse(sep: SqlFragment, elements: Iterable[SqlFragment]): SqlFragment = {
     var first = true
     elements.foldLeft(empty) { (acc, element) =>
       if (!first) acc ++ sep ++ element

--- a/core/src/main/scala/zio/jdbc/SqlFragment.scala
+++ b/core/src/main/scala/zio/jdbc/SqlFragment.scala
@@ -288,6 +288,22 @@ object SqlFragment {
   def fromFunction(f: ChunkBuilder[Segment] => Unit): SqlFragment =
     SqlFragment.FromFunction(f)
 
+  implicit final class FragmentOps[I[t] <: Iterable[t]](private val fragments: I[SqlFragment]) extends AnyVal {
+    def mkFragment(sep: SqlFragment): SqlFragment =
+      intersperse(sep, fragments)
+
+    def mkFragment(start: SqlFragment, sep: SqlFragment, end: SqlFragment): SqlFragment =
+      start ++ fragments.mkFragment(sep) ++ end
+  }
+
+  implicit final class NonEmptyChunkOps(private val fragments: NonEmptyChunk[SqlFragment]) extends AnyVal {
+    def mkFragment(sep: SqlFragment): SqlFragment =
+      fragments.toChunk.mkFragment(sep)
+
+    def mkFragment(start: SqlFragment, sep: SqlFragment, end: SqlFragment): SqlFragment =
+      fragments.toChunk.mkFragment(start, sep, end)
+  }
+
   sealed trait Segment
   object Segment {
     case object Empty                                       extends Segment


### PR DESCRIPTION
It's so gnarly to implement or import support for, and it's already there.

No reason to hide it, is there?


edit: added one more commit with a proposed `mkFragment` interface that I've found really nice in similar code in the past. It's an analogue to `mkString`