### PR TITLE
Fix `java.time.Instant` tests

### DIFF
--- a/integration/src/test/scala/zio/jdbc/JavaTimeSupportSpec.scala
+++ b/integration/src/test/scala/zio/jdbc/JavaTimeSupportSpec.scala
@@ -214,7 +214,7 @@ object JavaTimeSupportSpec extends PgSpec {
       test("java.time.Instant - now") {
         for {
           now <- ZIO.clockWith(_.instant)
-          _   <- transaction(sql"""CREATE TABLE instant (value TIMESTAMP)""".execute)
+          _   <- transaction(sql"""CREATE TABLE instant (value TIMESTAMP WITH TIME ZONE)""".execute)
           i   <- transaction(sql"""INSERT INTO instant VALUES ($now)""".insert)
           d   <- transaction(sql"""SELECT * FROM instant""".query[java.time.Instant].selectOne)
           _   <- transaction(sql"DROP TABLE instant".execute)
@@ -227,7 +227,7 @@ object JavaTimeSupportSpec extends PgSpec {
       test("java.time.Instant - Gen") {
         check(genPGInstant) { instant =>
           for {
-            _       <- transaction(sql"""CREATE TABLE instant (value TIMESTAMP)""".execute)
+            _       <- transaction(sql"""CREATE TABLE instant (value TIMESTAMP WITH TIME ZONE)""".execute)
             i       <- transaction(sql"""INSERT INTO instant VALUES ($instant)""".insert)
             d       <- transaction(sql"""SELECT * FROM instant""".query[java.time.Instant].selectOne)
             _       <- transaction(sql"DROP TABLE instant".execute)

--- a/integration/src/test/scala/zio/jdbc/PgSpec.scala
+++ b/integration/src/test/scala/zio/jdbc/PgSpec.scala
@@ -4,40 +4,29 @@ import org.testcontainers.containers.{ PostgreSQLContainer, PostgreSQLContainerP
 import zio.test.ZIOSpec
 import zio.{ ZIO, ZLayer }
 
-import java.util.TimeZone
-
 abstract class PgSpec extends ZIOSpec[ZConnectionPool] {
 
-  /**
-   * We need to set the JVM default timezone to UTC before doing anything else
-   * because this default time zone will be picked up by JDBC (See [[org.postgresql.jdbc.TimestampUtils.getDefaultTz]]
-   * and will be used to convert timestamps to UTC before to send them to the DB.
-   * When the computer on which tests are running is using UTC (like in CI, for example), that'll not change anything.
-   * When the computer on which tests are running is using another timezone, the `java.time.*` tests will fail because the saved timestamps will be converted to UTC from the computer timezone.
-   * So, we need to set the VM default timezone to UTC so that the tests are executed in the exact same way and produce the exact same results in the CI or on your local computer.
-   */
   override def bootstrap: ZLayer[Any, Throwable, ZConnectionPool] =
-    ZLayer.succeed(TimeZone.setDefault(TimeZone.getTimeZone("UTC"))) >>>
-      (ZLayer.scoped {
-        ZIO.fromAutoCloseable {
-          ZIO.attemptBlocking {
-            val provider = new PostgreSQLContainerProvider
-            val db       = provider.newInstance()
-            db.start()
-            db.asInstanceOf[PostgreSQLContainer[Nothing]]
-          }
+    (ZLayer.scoped {
+      ZIO.fromAutoCloseable {
+        ZIO.attemptBlocking {
+          val provider = new PostgreSQLContainerProvider
+          val db       = provider.newInstance()
+          db.start()
+          db.asInstanceOf[PostgreSQLContainer[Nothing]]
         }
-      } ++ ZLayer.succeed(ZConnectionPoolConfig.default)) >>> ZLayer.service[PostgreSQLContainer[Nothing]].flatMap {
-        env =>
-          val pg = env.get
-          ZConnectionPool.postgres(
-            host = "localhost",
-            port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
-            database = pg.getDatabaseName,
-            props = Map(
-              "user"     -> pg.getUsername,
-              "password" -> pg.getPassword
-            )
-          )
       }
+    } ++ ZLayer.succeed(ZConnectionPoolConfig.default)) >>> ZLayer.service[PostgreSQLContainer[Nothing]].flatMap {
+      env =>
+        val pg = env.get
+        ZConnectionPool.postgres(
+          host = "localhost",
+          port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+          database = pg.getDatabaseName,
+          props = Map(
+            "user"     -> pg.getUsername,
+            "password" -> pg.getPassword
+          )
+        )
+    }
 }


### PR DESCRIPTION
Dumb copy/paste mistake 😭

This comment made me doubt my code: https://github.com/pgjdbc/pgjdbc/issues/1325#issuecomment-439467466
Especially this line:

> As you can see the time java.sql.Timestamp -> java.time.Instant conversion depends on the JVM default time zone.

because it was what I was experiencing and why I had to set the JVM default timezone before starting the tests, which was, as @987Nabil was pointing out, weird.

Thanks @987Nabil for your review 🙂