### PR TITLE
Fix `bigDecimalDecoderScala` for Scala 2.12

### DIFF
--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -98,7 +98,7 @@ object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
   implicit val booleanDecoder: JdbcDecoder[Boolean]                       = JdbcDecoder(_.getBoolean)
   implicit val bigDecimalDecoder: JdbcDecoder[java.math.BigDecimal]       = JdbcDecoder(_.getBigDecimal)
   implicit val bigDecimalDecoderScala: JdbcDecoder[scala.math.BigDecimal] =
-    bigDecimalDecoder.map(scala.math.BigDecimal.javaBigDecimal2bigDecimal)
+    bigDecimalDecoder.map(v => if (v eq null) null else scala.math.BigDecimal.javaBigDecimal2bigDecimal(v))
   implicit val shortDecoder: JdbcDecoder[Short]                           = JdbcDecoder(_.getShort)
   implicit val floatDecoder: JdbcDecoder[Float]                           = JdbcDecoder(_.getFloat)
   implicit val byteDecoder: JdbcDecoder[Byte]                             = JdbcDecoder(_.getByte)

--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -98,6 +98,7 @@ object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
   implicit val booleanDecoder: JdbcDecoder[Boolean]                       = JdbcDecoder(_.getBoolean)
   implicit val bigDecimalDecoder: JdbcDecoder[java.math.BigDecimal]       = JdbcDecoder(_.getBigDecimal)
   implicit val bigDecimalDecoderScala: JdbcDecoder[scala.math.BigDecimal] =
+    // This `if null` check is only needed because of Scala 2.12. Can be removed once Scala 2.12 support is dropped.
     bigDecimalDecoder.map(v => if (v eq null) null else scala.math.BigDecimal.javaBigDecimal2bigDecimal(v))
   implicit val shortDecoder: JdbcDecoder[Short]                           = JdbcDecoder(_.getShort)
   implicit val floatDecoder: JdbcDecoder[Float]                           = JdbcDecoder(_.getFloat)

--- a/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
+++ b/core/src/main/scala/zio/jdbc/JdbcDecoder.scala
@@ -91,20 +91,20 @@ object JdbcDecoder extends JdbcDecoderLowPriorityImplicits {
         }
     }
 
-  implicit val intDecoder: JdbcDecoder[Int]                               = JdbcDecoder(_.getInt)
-  implicit val longDecoder: JdbcDecoder[Long]                             = JdbcDecoder(_.getLong)
-  implicit val doubleDecoder: JdbcDecoder[Double]                         = JdbcDecoder(_.getDouble)
-  implicit val stringDecoder: JdbcDecoder[String]                         = JdbcDecoder(_.getString)
-  implicit val booleanDecoder: JdbcDecoder[Boolean]                       = JdbcDecoder(_.getBoolean)
-  implicit val bigDecimalDecoder: JdbcDecoder[java.math.BigDecimal]       = JdbcDecoder(_.getBigDecimal)
+  implicit val intDecoder: JdbcDecoder[Int]                         = JdbcDecoder(_.getInt)
+  implicit val longDecoder: JdbcDecoder[Long]                       = JdbcDecoder(_.getLong)
+  implicit val doubleDecoder: JdbcDecoder[Double]                   = JdbcDecoder(_.getDouble)
+  implicit val stringDecoder: JdbcDecoder[String]                   = JdbcDecoder(_.getString)
+  implicit val booleanDecoder: JdbcDecoder[Boolean]                 = JdbcDecoder(_.getBoolean)
+  implicit val bigDecimalDecoder: JdbcDecoder[java.math.BigDecimal] = JdbcDecoder(_.getBigDecimal)
   implicit val bigDecimalDecoderScala: JdbcDecoder[scala.math.BigDecimal] =
     // This `if null` check is only needed because of Scala 2.12. Can be removed once Scala 2.12 support is dropped.
     bigDecimalDecoder.map(v => if (v eq null) null else scala.math.BigDecimal.javaBigDecimal2bigDecimal(v))
-  implicit val shortDecoder: JdbcDecoder[Short]                           = JdbcDecoder(_.getShort)
-  implicit val floatDecoder: JdbcDecoder[Float]                           = JdbcDecoder(_.getFloat)
-  implicit val byteDecoder: JdbcDecoder[Byte]                             = JdbcDecoder(_.getByte)
-  implicit val byteArrayDecoder: JdbcDecoder[Array[Byte]]                 = JdbcDecoder(_.getBytes)
-  implicit val blobDecoder: JdbcDecoder[Blob]                             = JdbcDecoder(_.getBlob)
+  implicit val shortDecoder: JdbcDecoder[Short]                     = JdbcDecoder(_.getShort)
+  implicit val floatDecoder: JdbcDecoder[Float]                     = JdbcDecoder(_.getFloat)
+  implicit val byteDecoder: JdbcDecoder[Byte]                       = JdbcDecoder(_.getByte)
+  implicit val byteArrayDecoder: JdbcDecoder[Array[Byte]]           = JdbcDecoder(_.getBytes)
+  implicit val blobDecoder: JdbcDecoder[Blob]                       = JdbcDecoder(_.getBlob)
   implicit val uuidDecoder: JdbcDecoder[java.util.UUID] =
     // See: https://stackoverflow.com/a/56267754/2431728
     JdbcDecoder(rs => i => rs.getObject(i, classOf[java.util.UUID]), "UUID")


### PR DESCRIPTION
In Scala 2.12, the `javaBigDecimal2bigDecimal` is not checking for null before the call `apply` while in Scala 2.13+, if does check, see:
- Scala 2.12: https://github.com/scala/scala/blob/2.12.x/src/library/scala/math/BigDecimal.scala#L347
- Scala 2.13: https://github.com/scala/scala/blob/2.13.x/src/library/scala/math/BigDecimal.scala#L307